### PR TITLE
Add --read-requirements option to check the requirements.txt

### DIFF
--- a/safety/cli.py
+++ b/safety/cli.py
@@ -1,10 +1,21 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import pip
 import sys
 import click
 from safety import __version__
 from safety import safety
 from safety.formatter import report
+
+
+def read_requirements_func():
+    with open('requirements.txt', 'r') as fh:
+        for line in fh.readlines():
+            parts = line.strip().split('>=')
+            if len(parts) > 1:
+                print(parts)
+                yield pip._vendor.pkg_resources.EggInfoDistribution(
+                          project_name=parts[0], version=parts[1])
 
 
 @click.group()
@@ -15,8 +26,12 @@ def cli():
 
 @cli.command()
 @click.option("--full-report/--short-report", default=False)
-def check(full_report):
-    vulns = safety.check()
+@click.option("--read-requirements/--no-read-requirements", default=False)
+def check(full_report, read_requirements):
+    if read_requirements:
+        vulns = safety.check(read_requirements_func)
+    else:
+        vulns = safety.check()
     click.secho(report(vulns=vulns, full=full_report))
     sys.exit(-1 if vulns else 0)
 

--- a/safety/safety.py
+++ b/safety/safety.py
@@ -46,12 +46,12 @@ def get_vulnerabilities(pkg, spec, db):
             yield entry
 
 
-def check():
+def check(pkginfo_func=pip.get_installed_distributions):
     db = fetch_database()
     db_full = None
     packages = frozenset(db.keys())
     vulnerable = []
-    for pkg in pip.get_installed_distributions():
+    for pkg in pkginfo_func():
         # normalize the package name, the safety-db is converting underscores to dashes and uses
         # lowercase
         name = pkg.key.replace("_", "-").lower()


### PR DESCRIPTION
This can be used to ensure the requirements.txt doesn't allow
insecure versions.

This only works for lines which actually specify a version.

This is only tested with 'pkg>=1.2.3' like lines.

With small modifications this could be made to parse `pip freeze`
output on stdin.

Related Issue: https://github.com/pyupio/safety/issues/2