### PR TITLE
Prevent access to invalid requirement property

### DIFF
--- a/safety/util.py
+++ b/safety/util.py
@@ -78,7 +78,7 @@ def read_requirements(fh, resolve=False):
                 else:
                     click.secho(
                         "Warning: unpinned requirement '{req}' found, unable to check.".format(
-                            req=req.name),
+                            req=req.project_name),
                         fg="yellow"
                     )
             except ValueError:


### PR DESCRIPTION
The setuptools documentation only documents the `project_name` attribute
for `Requirement` instances, so use it instead of `name`.

Closes #51