### PR TITLE
Fix get_terminal_size on Python 2.7 for Windows

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+Unreleased
+----------
+
+* Fixed a bug where absence of ``stty`` was causing a traceback in ``safety
+  check`` on Python 2.7 for Windows.
+
 1.4.0 (2017-04-21)
 ------------------
 

--- a/safety/formatter.py
+++ b/safety/formatter.py
@@ -27,10 +27,11 @@ except ImportError:
             rows, columns = subprocess.check_output(['stty', 'size']).split()
             return size(rows=int(rows), columns=int(columns))
         # this won't work
-        # - on windows (FileNotFoundError)
+        # - on windows (FileNotFoundError/OSError)
         # - python 2.6 (AttributeError)
         # - if the output is somehow mangled (ValueError)
-        except (ValueError, FileNotFoundError, AttributeError, subprocess.CalledProcessError):
+        except (ValueError, FileNotFoundError, OSError,
+                AttributeError, subprocess.CalledProcessError):
             return size(rows=0, columns=0)
 
 


### PR DESCRIPTION
The code was correctly trapping `FileNotFoundError` for the case where `stty`
is not available on Windows.  However, on Python 2.7, the exception raised by
`subprocess.check_output()` is `WindowsError`, a subclass of `OSError`.

Fixes #65.