### PR TITLE
Allows multiple versions of same library in check

### DIFF
--- a/safety/safety.py
+++ b/safety/safety.py
@@ -123,12 +123,10 @@ def get_vulnerabilities(pkg, spec, db):
 def check(packages, key, db_mirror, cached, ignore_ids):
 
     key = key if key else os.environ.get("SAFETY_API_KEY", False)
-
     db = fetch_database(key=key, db=db_mirror, cached=cached)
     db_full = None
     vulnerable_packages = frozenset(db.keys())
     vulnerable = []
-    found_ids = set()
     for pkg in packages:
         # normalize the package name, the safety-db is converting underscores to dashes and uses
         # lowercase
@@ -143,7 +141,7 @@ def check(packages, key, db_mirror, cached, ignore_ids):
                         db_full = fetch_database(full=True, key=key, db=db_mirror)
                     for data in get_vulnerabilities(pkg=name, spec=specifier, db=db_full):
                         vuln_id = data.get("id").replace("pyup.io-", "")
-                        if vuln_id not in found_ids and vuln_id not in ignore_ids:
+                        if vuln_id and vuln_id not in ignore_ids:
                             vulnerable.append(
                                 Vulnerability(
                                     name=name,
@@ -153,5 +151,4 @@ def check(packages, key, db_mirror, cached, ignore_ids):
                                     vuln_id=vuln_id
                                 )
                             )
-                            found_ids.add(vuln_id)
     return vulnerable

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -70,6 +70,21 @@ class TestSafety(unittest.TestCase):
         )
         self.assertEqual(len(vulns), 2)
 
+    def test_multiple_versions(self):
+        reqs = StringIO("Django==1.8.1\n\rDjango==1.7.0")
+        packages = util.read_requirements(reqs)
+
+        vulns = safety.check(
+            packages=packages,
+            db_mirror=os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                "test_db"
+            ),
+            cached=False,
+            key=False,
+            ignore_ids=[]
+        )
+        self.assertEqual(len(vulns), 4)
     def test_check_live(self):
         reqs = StringIO("insecure-package==0.1")
         packages = util.read_requirements(reqs)


### PR DESCRIPTION
Addresses https://github.com/pyupio/safety/issues/80

Since the `found_ids` set specifically blocks this behavior, I don't know if this is wanted from the maintainers. I'm up for a discussion since this change is very helpful for me.


Signed-off-by: Kevin <kevin@stealsyour.pw>