### PR TITLE
Suppress stderr output from stty when it fails

### DIFF
--- a/safety/formatter.py
+++ b/safety/formatter.py
@@ -24,7 +24,10 @@ except ImportError:
     def get_terminal_size():
         size = namedtuple("_", ["rows", "columns"])
         try:
-            rows, columns = subprocess.check_output(['stty', 'size']).split()
+            rows, columns = subprocess.check_output(
+                ['stty', 'size'],
+                stderr=subprocess.STDOUT
+            ).split()
             return size(rows=int(rows), columns=int(columns))
         # this won't work
         # - on windows (FileNotFoundError/OSError)


### PR DESCRIPTION
When call to stty fails for whatever reason we get ugly error
message that's not connected to `safety` itself.

Example:

```
$ safety check -r dependencies.txt
stty: 'standard input': Inappropriate ioctl for device
safety report
---
-> django, installed 1.9.10, affected >=1.9,<1.9.11, id 33075
-> django, installed 1.9.10, affected >=1.9,<1.9.11, id 33076
-> django, installed 1.9.10, affected >=1.9,<1.9.11, id 25734
-> django, installed 1.9.10, affected >=1.9,<1.9.13, id 33302
```