### PR TITLE
variable-width space fill in SheetReport

### DIFF
--- a/safety/formatter.py
+++ b/safety/formatter.py
@@ -90,9 +90,10 @@ class SheetReport(object):
 
     @staticmethod
     def render(vulns, full, checked_packages, used_db):
-        status = "│ checked {packages} packages, using {db: <50} │".format(
+        db_format_str = '{: <' + str(51 - len(str(checked_packages))) + '}'
+        status = "│ checked {packages} packages, using {db} │".format(
             packages=checked_packages,
-            db=used_db,
+            db=db_format_str.format(used_db),
             section=SheetReport.REPORT_SECTION
         )
         if vulns:


### PR DESCRIPTION
Fixes space fill so the table border always lines up correctly (see #101)

I'm not sure there's a more elegant way to do this with format strings :-/