### PR TITLE
Replaced use of pip internal function.

### DIFF
--- a/safety/cli.py
+++ b/safety/cli.py
@@ -15,7 +15,10 @@ try:
     from pip import get_installed_distributions
 except ImportError:
     # pip 10
-    from pip._internal.utils.misc import get_installed_distributions
+    import pkg_resources
+
+    def get_installed_distributions():
+        return [d for d in pkg_resources.working_set]
 
 
 @click.group()


### PR DESCRIPTION
As discussed in this thread: https://github.com/pypa/pip/issues/5243
use of the functions inside pip._internal is strongly discouraged. As
such I have replaced this functions usage with the pip maintainers
recommended solution.