### PR TITLE
issue-131: write log messages to stderr instead of stdout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ target/
 # pyenv python configuration file
 .python-version
 sandbox.py
+
+# PyCharm
+.idea

--- a/safety/cli.py
+++ b/safety/cli.py
@@ -49,7 +49,7 @@ def cli():
 def check(key, db, json, full_report, bare, stdin, files, cache, ignore):
 
     if files and stdin:
-        click.secho("Can't read from --stdin and --file at the same time, exiting", fg="red")
+        click.secho("Can't read from --stdin and --file at the same time, exiting", fg="red", file=sys.stderr)
         sys.exit(-1)
 
     if files:
@@ -75,13 +75,14 @@ def check(key, db, json, full_report, bare, stdin, files, cache, ignore):
     except InvalidKeyError:
         click.secho("Your API Key '{key}' is invalid. See {link}".format(
             key=key, link='https://goo.gl/O7Y1rS'),
-            fg="red")
+            fg="red",
+            file=sys.stderr)
         sys.exit(-1)
     except DatabaseFileNotFoundError:
-        click.secho("Unable to load vulnerability database from {db}".format(db=db), fg="red")
+        click.secho("Unable to load vulnerability database from {db}".format(db=db), fg="red", file=sys.stderr)
         sys.exit(-1)
     except DatabaseFetchError:
-        click.secho("Unable to load vulnerability database", fg="red")
+        click.secho("Unable to load vulnerability database", fg="red", file=sys.stderr)
         sys.exit(-1)
 
 

--- a/safety/util.py
+++ b/safety/util.py
@@ -1,6 +1,7 @@
 from dparse.parser import setuptools_parse_requirements_backport as _parse_requirements
 from collections import namedtuple
 import click
+import sys
 import os
 Package = namedtuple("Package", ["key", "version"])
 RequirementFile = namedtuple("RequirementFile", ["path"])
@@ -85,7 +86,8 @@ def read_requirements(fh, resolve=False):
                         "Warning: unpinned requirement '{req}' found in {fname}, "
                         "unable to check.".format(req=req.name,
                                                   fname=fname),
-                        fg="yellow"
+                        fg="yellow",
+                        file=sys.stderr
                     )
             except ValueError:
                 continue


### PR DESCRIPTION
Log messages should go to stderr. This way others can use `safety` inside their own scripts without getting stdout all mixed up.