### PR TITLE
Fix format type error from encode addition

### DIFF
--- a/safety/formatter.py
+++ b/safety/formatter.py
@@ -113,7 +113,10 @@ class SheetReport(object):
                     for chunk in [descr[i:i + 76] for i in range(0, len(descr), 76)]:
 
                         for line in chunk.splitlines():
-                            table.append("│ {:76} │".format(line.encode('utf-8')))
+                            try:
+                                table.append("│ {:76} │".format(line.encode('utf-8')))
+                            except TypeError:
+                                table.append("│ {:76} │".format(line))
                     # append the REPORT_SECTION only if this isn't the last entry
                     if n + 1 < len(vulns):
                         table.append(SheetReport.REPORT_SECTION)


### PR DESCRIPTION
This fixes a format type error some users are encountering after we moved to utf-8 encoding from [this commit](https://github.com/pyupio/safety/commit/1666851cf32a850e482ebb641c48f48fb8045c61).

Since some users require utf-8 encoding (the reason for the original change) I added a try catch which tries uft-8 encoding first, and if that fails falls back without it.

Issue discussion [here](https://github.com/pyupio/safety/issues/141)