### PR TITLE
Remove API dependency on pip.

### DIFF
--- a/safety/cli.py
+++ b/safety/cli.py
@@ -10,14 +10,6 @@ from safety.util import read_requirements
 from safety.errors import DatabaseFetchError, DatabaseFileNotFoundError, InvalidKeyError
 
 
-try:
-    # pip 9
-    from pip import get_installed_distributions
-except ImportError:
-    # pip 10
-    from pip._internal.utils.misc import get_installed_distributions
-
-
 @click.group()
 @click.version_option(version=__version__)
 def cli():
@@ -57,7 +49,11 @@ def check(key, db, json, full_report, bare, stdin, files, cache, ignore):
     elif stdin:
         packages = list(read_requirements(sys.stdin))
     else:
-        packages = get_installed_distributions()
+        import pkg_resources
+        packages = [
+            d for d in pkg_resources.working_set
+            if d.key not in {"python", "wsgiref", "argparse"}
+        ]
 
     try:
         vulns = safety.check(packages=packages, key=key, db_mirror=db, cached=cache, ignore_ids=ignore)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ except TypeError:
         history = history_file.read()
 
 requirements = [
-    'pip',
+    'setuptools',
     'Click>=6.0',
     'requests',
     'packaging',


### PR DESCRIPTION
pip doesn't have a public API. This more-or-less inlines https://github.com/pypa/pip/blob/404838abcca467648180b358598c597b74d568c9/src/pip/_internal/utils/misc.py#L340-L394.

Fixes #90.