### PR TITLE
Added Dockerfile and readme instructions #155

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.6-slim
+RUN pip install --trusted-host pypi.python.org safety
+CMD ["python"]

--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ echo "insecure-package==0.1" | safety check --stdin
 
 *For more examples, take a look at the [options](#options) section.*
 
+## Using Safety in Docker
+
+Safety can be easily executed as Docker container. To build the container just execute:
+```
+docker build -t safety-docker .
+```
+
+The container can be used just as described in the [examples](#examples) section.
+```
+echo "insecure-package==0.1" | docker run -i --rm safety-docker safety check --stdin
+cat requirements_dev.txt | docker run -i --rm safety-docker safety check --stdin
+```
+
 ## Using Safety with a CI service
 
 Safety works great in your CI pipeline. It returns a non-zero exit status if it finds a vulnerability. 


### PR DESCRIPTION
Referencing issue #155 I added a minimal Dockerfile and usage instructions to the Readme. Use in e.g. gitlab-ci with:

```
safety:
    image: safety
    stage: test
    script:
        - export HTTPS_PROXY="https://${PROXY_HOST}:${PROXY_PORT}"
        - safety check -r requirements.txt --full-report
```