### PR TITLE
Wrap words in full report

### DIFF
--- a/safety/formatter.py
+++ b/safety/formatter.py
@@ -3,6 +3,7 @@ import platform
 import sys
 import json
 import os
+import textwrap
 
 # python 2.7 compat
 try:
@@ -110,9 +111,10 @@ class SheetReport(object):
 
                     descr = get_advisory(vuln)
 
-                    for chunk in [descr[i:i + 76] for i in range(0, len(descr), 76)]:
-
-                        for line in chunk.splitlines():
+                    for pn, paragraph in enumerate(descr.replace('\r', '').split('\n\n')):
+                        if pn:
+                            table.append("│ {:76} │".format(''))
+                        for line in textwrap.wrap(paragraph, width=76):
                             try:
                                 table.append("│ {:76} │".format(line.encode('utf-8')))
                             except TypeError:


### PR DESCRIPTION
Before:

```
╞════════════════════════════╤═══════════╤══════════════════════════╤══════════╡
│ package                    │ installed │ affected                 │ ID       │
╞════════════════════════════╧═══════════╧══════════════════════════╧══════════╡
│ collins-client             │ 2.0.0     │ <2.1.0                   │ 25667    │
╞══════════════════════════════════════════════════════════════════════════════╡
│ Collins 2.1.0 has a very important security patch.                           │
│                                                                              │
│ Collins has a feature                                                        │
│ that allows you to [encrypt certain attributes](http://tumblr.github.io/coll │
│ ins/configuration.htmlfeatures) on every asset.  It also had a permission th │
│ at restricted which users could read those encrypted tags.  It did NOT have  │
│ a permission that restricted which users could modify encrypted tags.        │
│                                                                              │
│ *It                                                                          │
│  is strongly recommended that you upgrade to collins 2.1.0 if you are using  │
│ the encrypted tags feature, as well as rotate any values stored in encrypted │
│  tags.*                                                                      │
│                                                                              │
│ The severity of this vulnerability depends heavily upon how you u            │
│ se collins in your infrastructure.  If you do not use the encrypted tags fea │
│ ture, you are not vulnerable to this problem.  If you do use the encrypted t │
│ ags feature, you will need to explore your automation and consider how vulne │
│ rable you are.                                                               │
│                                                                              │
│ If, for example, your infrastructure has automation that r                   │
│ egularly sets the root password on servers to match a value that is in colli │
│ ns, an attacker without the ability to read the current password could set i │
│ t to a value that they know, wait for the automation to change the password, │
│  and then gain root on a server.                                             │
│                                                                              │
│ This change is backwards compatible with                                     │
│  collins v2.0.0, though once you upgrade it will stop any writes to encrypte │
│ d tags by users that have not been granted `feature.canWriteEncryptedTags` p │
│ ermission.  We have also renamed `feature.canSeePasswords` to `feature.canSe │
│ eEncryptedTags`, but collins will continue to respect the value of `feature. │
│ canSeePasswords` if `feature.canSeeEncryptedTags` is not set.  Once `feature │
│ .canSeeEncryptedTags` is set, collins will ignore the value of `feature.canS │
│ eePasswords`.                                                                │
╘══════════════════════════════════════════════════════════════════════════════╛
```

after:

```
╞════════════════════════════╤═══════════╤══════════════════════════╤══════════╡
│ package                    │ installed │ affected                 │ ID       │
╞════════════════════════════╧═══════════╧══════════════════════════╧══════════╡
│ collins-client             │ 2.0.0     │ <2.1.0                   │ 25667    │
╞══════════════════════════════════════════════════════════════════════════════╡
│ Collins 2.1.0 has a very important security patch.                           │
│                                                                              │
│ Collins has a feature that allows you to [encrypt certain                    │
│ attributes](http://tumblr.github.io/collins/configuration.htmlfeatures) on   │
│ every asset.  It also had a permission that restricted which users could     │
│ read those encrypted tags.  It did NOT have a permission that restricted     │
│ which users could modify encrypted tags.                                     │
│                                                                              │
│ *It is strongly recommended that you upgrade to collins 2.1.0 if you are     │
│ using the encrypted tags feature, as well as rotate any values stored in     │
│ encrypted tags.*                                                             │
│                                                                              │
│ The severity of this vulnerability depends heavily upon how you use collins  │
│ in your infrastructure.  If you do not use the encrypted tags feature, you   │
│ are not vulnerable to this problem.  If you do use the encrypted tags        │
│ feature, you will need to explore your automation and consider how           │
│ vulnerable you are.                                                          │
│                                                                              │
│ If, for example, your infrastructure has automation that regularly sets the  │
│ root password on servers to match a value that is in collins, an attacker    │
│ without the ability to read the current password could set it to a value     │
│ that they know, wait for the automation to change the password, and then     │
│ gain root on a server.                                                       │
│                                                                              │
│ This change is backwards compatible with collins v2.0.0, though once you     │
│ upgrade it will stop any writes to encrypted tags by users that have not     │
│ been granted `feature.canWriteEncryptedTags` permission.  We have also       │
│ renamed `feature.canSeePasswords` to `feature.canSeeEncryptedTags`, but      │
│ collins will continue to respect the value of `feature.canSeePasswords` if   │
│ `feature.canSeeEncryptedTags` is not set.  Once                              │
│ `feature.canSeeEncryptedTags` is set, collins will ignore the value of       │
│ `feature.canSeePasswords`.                                                   │
╘══════════════════════════════════════════════════════════════════════════════╛
```