### PR TITLE
Decompose safety.check into multiple functions to allow checking without fetching the database.

### DIFF
--- a/safety/safety.py
+++ b/safety/safety.py
@@ -10,7 +10,7 @@ import time
 import errno
 
 class Candidate(namedtuple("Candidate",
-                           ["name", "version", "spec"]):
+                           ["name", "version", "spec"])):
     pass
 
 
@@ -141,7 +141,7 @@ def find_candidates(packages, db):
                         Candidate(
                             name=name,
                             spec=specifier,
-                            version=version
+                            version=pkg.version
                         )
                     )
     return candidates


### PR DESCRIPTION
I've tried to preserve existing behavior with this PR while also providing an interface that allows packages to be checked without fetching the database. This change allows a use case like:

```
import safety, safety_db

...

candidates = safety.find_candidates(packages, safety_db.INSECURE)
safety.check_candidates(candidates, safety_db.INSECURE_FULL, [])
```