### PR TITLE
added check for cache if bad response from server

### DIFF
--- a/safety/safety.py
+++ b/safety/safety.py
@@ -84,6 +84,10 @@ def fetch_database_url(mirror, db_name, key, cached, proxy):
         return data
     elif r.status_code == 403:
         raise InvalidKeyError()
+    else:
+        cached_data = get_from_cache(db_name=db_name)
+        if cached_data:
+            return cached_data
 
 
 def fetch_database_file(path, db_name):

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -175,8 +175,8 @@ class TestSafety(unittest.TestCase):
             ignore_ids=[],
             proxy={}
         )
-        self.assertEqual(len(vulns), 1)
-
+        self.assertEqual(len(vulns), 1)    
+    
     def test_check_live_cached(self):
         reqs = StringIO("insecure-package==0.1")
         packages = util.read_requirements(reqs)
@@ -204,7 +204,34 @@ class TestSafety(unittest.TestCase):
         )
         self.assertEqual(len(vulns), 1)
 
+    def test_check_live_down_cached(self):
+        reqs = StringIO("insecure-package==0.1")
+        packages = util.read_requirements(reqs)
 
+        vulns = safety.check(
+            packages=packages,
+            db_mirror=False,
+            cached=True,
+            key=False,
+            ignore_ids=[],
+            proxy={}
+        )
+        self.assertEqual(len(vulns), 1)
+        
+        reqs = StringIO("insecure-package==0.1")
+        packages = util.read_requirements(reqs)
+        # make a second call, where server responds with 400 error, so use
+        # the cache
+        vulns = safety.check(
+            packages=packages,
+            db_mirror="http://pyup.io/",
+            cached=False,
+            key=False,
+            ignore_ids=[],
+            proxy={}
+        )
+        self.assertEqual(len(vulns), 1)
+    
 class ReadRequirementsTestCase(unittest.TestCase):
 
     def test_unpinned_vcs_requirement(self):


### PR DESCRIPTION
If the remote safety db is down (this happened on 2/15), is it reasonable to check to see if there has been anything cached locally, even if `--cache` is not `true` at the time?