### PR TITLE
add support for Pipfile.lock

### DIFF
--- a/safety/util.py
+++ b/safety/util.py
@@ -96,3 +96,13 @@ def read_requirements(fh, resolve=False):
                     )
             except ValueError:
                 continue
+
+
+def read_pipfile(fh):
+    """
+    Reads Pipfile.lock
+    :param fh: file like object to read from
+    :return: generator
+    """
+    for key, data in json.load(fh)['default'].items():
+        yield Package(key=key, version=data['version'].replace('==', ''))

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -23,7 +23,7 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
-from safety.util import read_requirements
+from safety.util import read_requirements, read_pipfile
 from safety.util import read_vulnerabilities
 
 
@@ -132,6 +132,23 @@ class TestSafety(unittest.TestCase):
     def test_check_from_file(self):
         reqs = StringIO("Django==1.8.1")
         packages = util.read_requirements(reqs)
+
+        vulns = safety.check(
+            packages=packages,
+            db_mirror=os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                "test_db"
+            ),
+            cached=False,
+            key=False,
+            ignore_ids=[],
+            proxy={}
+        )
+        self.assertEqual(len(vulns), 2)
+
+    def test_check_from_pipfile(self):
+        reqs = StringIO(json.dumps({'default': {'django': {'version': '==1.8.1'}}}))
+        packages = util.read_pipfile(reqs)
 
         vulns = safety.check(
             packages=packages,


### PR DESCRIPTION
Hi,

This PR adds support for `Pipfile.lock` (https://github.com/pypa/pipfile), with a new `-p` option for the CLI, a really simple `read_pipfile` util inspired from the existing `read_requirements`, and a unit test.

Another option to add this suppport (and support other formats), would be to refactor `read_requirements` to let dparse get the requirements from multiple formats, maybe with a CLI switch with `dparse.filetypes` as choices.