### PR TITLE
Fix error message for invalid API Key from environment variable

### DIFF
--- a/safety/cli.py
+++ b/safety/cli.py
@@ -21,7 +21,7 @@ def cli():
 
 
 @cli.command()
-@click.option("--key", default="",
+@click.option("--key", default="", envvar="SAFETY_API_KEY",
               help="API Key for pyup.io's vulnerability database. Can be set as SAFETY_API_KEY "
                    "environment variable. Default: empty")
 @click.option("--db", default="",


### PR DESCRIPTION
When an invalid API Key is specified via the --key option, Safety displays an error message like:

    Your API Key '12345-ABCDEFGH' is invalid. See https://goo.gl/O7Y1rS

However, when an invalid API Key is specified via the SAFETY_API_KEY environment variable, the error message doesn't include the key:

    Your API Key '' is invalid. See https://goo.gl/O7Y1rS

This commit fixes the error message when the API Key is specified via the environment variable.