### PR TITLE
Fix -r inside requirements.txt files (#132)

### DIFF
--- a/safety/util.py
+++ b/safety/util.py
@@ -54,7 +54,14 @@ def read_requirements(fh, resolve=False):
             # if this is a tempfile, skip
             if is_temp_file:
                 continue
-            filename = line.strip("-r ").strip("--requirement").strip()
+
+            # strip away the recursive flag
+            prefixes = ["-r ", "--requirement "]
+            filename = line.strip()
+            for prefix in prefixes:
+                if filename.startswith(prefix):
+                    filename = filename[len(prefix):]
+
             # if there is a comment, remove it
             if " #" in filename:
                 filename = filename.split(" #")[0].strip()

--- a/safety/util.py
+++ b/safety/util.py
@@ -56,11 +56,11 @@ def read_requirements(fh, resolve=False):
                 continue
 
             # strip away the recursive flag
-            prefixes = ["-r ", "--requirement "]
+            prefixes = ["-r", "--requirement"]
             filename = line.strip()
             for prefix in prefixes:
                 if filename.startswith(prefix):
-                    filename = filename[len(prefix):]
+                    filename = filename[len(prefix):].strip()
 
             # if there is a comment, remove it
             if " #" in filename:

--- a/tests/reqs_1.txt
+++ b/tests/reqs_1.txt
@@ -1,0 +1,1 @@
+-r reqs_2.txt

--- a/tests/reqs_2.txt
+++ b/tests/reqs_2.txt
@@ -1,0 +1,2 @@
+insecure-package==0.1.0
+--requirement reqs_3.txt # with comment

--- a/tests/reqs_3.txt
+++ b/tests/reqs_3.txt
@@ -1,0 +1,1 @@
+insecure-package==0.1.1

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -127,7 +127,7 @@ class TestSafety(unittest.TestCase):
             input_vulns = read_vulnerabilities(insecure)
 
         vulns = safety.review(input_vulns)
-        assert(len(vulns), 3)
+        self.assertEqual(len(vulns), 3)
 
     def test_check_from_file(self):
         reqs = StringIO("Django==1.8.1")
@@ -234,3 +234,13 @@ class ReadRequirementsTestCase(unittest.TestCase):
         result = list(read_requirements(content))
         self.assertEqual(len(result), 0)
 
+    def test_recursive_requirement(self):
+        """
+        https://github.com/pyupio/safety/issues/132
+        """
+        # this should find 2 bad packages
+        dirname = os.path.dirname(__file__)
+        test_filename = os.path.join(dirname, "reqs_1.txt")
+        with open(test_filename) as fh:
+            result = list(read_requirements(fh, resolve=True))
+        self.assertEqual(len(result), 2)


### PR DESCRIPTION
This fixes Issue #132 to support using "-r" inside requirements.txt files.

There was already logic to handle these files, but there was a bug in the string parsing.

Tested on Ubuntu 18.04 with python 2.7.17 and 3.6.9.

```
$ cat tests/reqs_1.txt 
-r reqs_2.txt

$ cat tests/reqs_2.txt 
insecure-package==0.1.0
--requirement reqs_3.txt # with comment

$ cat tests/reqs_3.txt 
insecure-package==0.1.1

$ safety check -r tests/reqs_1.txt 
...
│ insecure-package           │ 0.1.0     │ <0.2.0                   │ 25853    │
│ insecure-package           │ 0.1.1     │ <0.2.0                   │ 25853    │
...
```