### PR TITLE
Adds missing space to `--bare` description

### DIFF
--- a/safety/cli.py
+++ b/safety/cli.py
@@ -32,7 +32,8 @@ def cli():
               help='Full reports include a security advisory (if available). Default: '
                    '--short-report')
 @click.option("--bare/--not-bare", default=False,
-              help='Output vulnerable packages only. Useful in combination with other tools.'
+              help='Output vulnerable packages only. '
+                   'Useful in combination with other tools. '
                    'Default: --not-bare')
 @click.option("--cache/--no-cache", default=False,
               help="Cache requests to the vulnerability database locally. Default: --no-cache")


### PR DESCRIPTION
That's how it used to look like:

```
  --bare / --not-bare             Output vulnerable packages only. Useful in
                                  combination with other tools.Default: --not-
                                  bare
```

Note the `tools.Default:` part.