### PR TITLE
Python Packaging improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from io import open  # Python 2 compatibility
 
 from setuptools import setup
 
-# there are problems to run setup.py on windows if the encoding is not set.
-# additionally, supplying the encoding isn't supported on 2.7
-# wrap all of this an ugly try/catch block
-try:
-    with open('README.md', encoding='utf8') as readme_file:
-        readme = readme_file.read()
-    with open('HISTORY.rst', encoding='utf8') as history_file:
-        history = history_file.read()
-except TypeError:
-    with open('README.md') as readme_file:
-        readme = readme_file.read()
-    with open('HISTORY.rst') as history_file:
-        history = history_file.read()
+# There are problems running setup.py on Windows if the encoding is not set
+with open('README.md', encoding='utf8') as readme_file:
+    readme = readme_file.read()
+with open('HISTORY.rst', encoding='utf8') as history_file:
+    history = history_file.read()
 
-requirements = [
-    'setuptools',
-    'Click>=6.0',
-    'requests',
-    'packaging',
-    'dparse>=0.4.1'
-]
 
 setup(
     name='safety',
@@ -44,7 +30,14 @@ setup(
         ]
     },
     include_package_data=True,
-    install_requires=requirements,
+    install_requires=[
+        'setuptools',
+        'Click>=6.0',
+        'requests',
+        'packaging',
+        'dparse>=0.4.1'
+    ],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     license="MIT license",
     zip_safe=False,
     keywords='safety',


### PR DESCRIPTION
- Use 'io' package as a more reliable way of opening files
  on Windows in Python 2.7
- Add python_requires, which helps pip determine if the
  package is compatible with the user's installed version of Python.
- Cleanup and formatting of setup.py