### PR TITLE
Added example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ echo "insecure-package==0.1" | safety check --stdin
 
 *For more examples, take a look at the [options](#options) section.*
 
+
+### Scan a Python-based Docker image
+
+To scan a docker image `IMAGE_TAG`, you can run
+
+```console
+docker run -it --rm ${IMAGE_TAG} "/bin/bash -c \"pip install safety && safety check\"
+```
+
 ## Using Safety in Docker
 
 Safety can be easily executed as Docker container. It can be used just as


### PR DESCRIPTION
Add a small snippet that scans an existing docker image. This ensures that the check
is done on the final installation - which may be deployed in production - as opposed
to the requirements.txt, which often (i.e. in the wild) does not contain all dependencies 
or the complete state of the installed dependencies (e.g. wheel, setuptools).