### PR TITLE
Package license information on Safety.

### DIFF
--- a/safety/cli.py
+++ b/safety/cli.py
@@ -4,9 +4,9 @@ import sys
 import click
 from safety import __version__
 from safety import safety
-from safety.formatter import report
+from safety.formatter import report, license_report
 import itertools
-from safety.util import read_requirements, read_vulnerabilities
+from safety.util import read_requirements, read_vulnerabilities, get_proxy_dict
 from safety.errors import DatabaseFetchError, DatabaseFileNotFoundError, InvalidKeyError
 
 try:
@@ -42,8 +42,6 @@ def cli():
               help="Read input from one (or multiple) requirement files. Default: empty")
 @click.option("ignore", "--ignore", "-i", multiple=True, type=str, default=[],
               help="Ignore one (or multiple) vulnerabilities by ID. Default: empty")
-@click.option("--licenses-only/--vulnerabilities-only", default=False,
-              help="Display packages licenses (if available). Default: --vulnerabilities-only")
 @click.option("--output", "-o", default="",
               help="Path to where output file will be placed. Default: empty")
 @click.option("proxyhost", "--proxy-host", "-ph", multiple=False, type=str, default=None,
@@ -52,7 +50,7 @@ def cli():
               help="Proxy port number --proxy-port")
 @click.option("proxyprotocol", "--proxy-protocol", "-pr", multiple=False, type=str, default='http',
               help="Proxy protocol (https or http) --proxy-protocol")
-def check(key, db, json, full_report, bare, licenses_only, stdin, files, cache, ignore, output, proxyprotocol, proxyhost, proxyport):
+def check(key, db, json, full_report, bare, stdin, files, cache, ignore, output, proxyprotocol, proxyhost, proxyport):
     if files and stdin:
         click.secho("Can't read from --stdin and --file at the same time, exiting", fg="red", file=sys.stderr)
         sys.exit(-1)
@@ -67,21 +65,14 @@ def check(key, db, json, full_report, bare, licenses_only, stdin, files, cache, 
             d for d in pkg_resources.working_set
             if d.key not in {"python", "wsgiref", "argparse"}
         ]    
-    proxy_dictionary = {}
-    if proxyhost is not None:
-        if proxyprotocol in ["http", "https"]:
-            proxy_dictionary = {proxyprotocol: "{0}://{1}:{2}".format(proxyprotocol, proxyhost, str(proxyport))}
-        else:
-            click.secho("Proxy Protocol should be http or https only.", fg="red")
-            sys.exit(-1)
+    proxy_dictionary = get_proxy_dict(proxyprotocol, proxyhost, proxyport)
     try:
-        vulns, licenses_dict = safety.check(packages=packages, key=key, db_mirror=db, cached=cache, ignore_ids=ignore, proxy=proxy_dictionary, licenses_only=licenses_only)
+        vulns = safety.check(packages=packages, key=key, db_mirror=db, cached=cache, ignore_ids=ignore, proxy=proxy_dictionary)
         output_report = report(vulns=vulns, 
                                full=full_report, 
                                json_report=json, 
                                bare_report=bare,
                                checked_packages=len(packages),
-                               licenses=licenses_dict,
                                db=db, 
                                key=key)
 
@@ -128,6 +119,40 @@ def review(full_report, bare, file):
     vulns = safety.review(input_vulns)
     output_report = report(vulns=vulns, full=full_report, bare_report=bare)
     click.secho(output_report, nl=False if bare and not vulns else True)
+
+
+@cli.command()
+@click.option("--key", default="", envvar="SAFETY_API_KEY",
+              help="API Key for pyup.io's vulnerability database. Can be set as SAFETY_API_KEY "
+                   "environment variable. Default: empty")
+@click.option("--db", default="",
+              help="Path to a local license database. Default: empty")
+@click.option("--cache/--no-cache", default=True,
+              help='Whether license database file should be cached.'
+                   'Default: --cache')
+@click.option("files", "--file", "-r", multiple=True, type=click.File(),
+              help="Read input from one (or multiple) requirement files. Default: empty")
+@click.option("proxyhost", "--proxy-host", "-ph", multiple=False, type=str, default=None,
+              help="Proxy host IP or DNS --proxy-host")
+@click.option("proxyport", "--proxy-port", "-pp", multiple=False, type=int, default=80,
+              help="Proxy port number --proxy-port")
+@click.option("proxyprotocol", "--proxy-protocol", "-pr", multiple=False, type=str, default='http',
+              help="Proxy protocol (https or http) --proxy-protocol")
+def license(key, db, cache, files, proxyprotocol, proxyhost, proxyport):
+
+    if files:
+        packages = list(itertools.chain.from_iterable(read_requirements(f, resolve=True) for f in files))
+    else:
+        import pkg_resources
+        packages = [
+            d for d in pkg_resources.working_set
+            if d.key not in {"python", "wsgiref", "argparse"}
+        ]  
+   
+    proxy_dictionary = get_proxy_dict(proxyprotocol, proxyhost, proxyport)
+    licenses = safety.get_licenses(key, db, cache, proxy_dictionary)
+    output_report = license_report(packages=packages, licenses_db=licenses)
+    click.secho(output_report, nl=True)
 
 
 if __name__ == "__main__":

--- a/safety/cli.py
+++ b/safety/cli.py
@@ -6,7 +6,7 @@ from safety import __version__
 from safety import safety
 from safety.formatter import report, license_report
 import itertools
-from safety.util import read_requirements, read_vulnerabilities, get_proxy_dict
+from safety.util import read_requirements, read_vulnerabilities, get_proxy_dict, get_packages_licenses
 from safety.errors import DatabaseFetchError, DatabaseFileNotFoundError, InvalidKeyError
 
 try:
@@ -150,8 +150,9 @@ def license(key, db, cache, files, proxyprotocol, proxyhost, proxyport):
         ]  
    
     proxy_dictionary = get_proxy_dict(proxyprotocol, proxyhost, proxyport)
-    licenses = safety.get_licenses(key, db, cache, proxy_dictionary)
-    output_report = license_report(packages=packages, licenses_db=licenses)
+    licenses_db = safety.get_licenses(key, db, cache, proxy_dictionary)
+    filtered_packages_licenses = get_packages_licenses(packages, licenses_db)
+    output_report = license_report(packages=packages, licenses=filtered_packages_licenses)
     click.secho(output_report, nl=True)
 
 

--- a/safety/cli.py
+++ b/safety/cli.py
@@ -42,6 +42,8 @@ def cli():
               help="Read input from one (or multiple) requirement files. Default: empty")
 @click.option("ignore", "--ignore", "-i", multiple=True, type=str, default=[],
               help="Ignore one (or multiple) vulnerabilities by ID. Default: empty")
+@click.option("--licenses-only/--vulnerabilities-only", default=False,
+              help="Display packages licenses (if available). Default: --vulnerabilities-only")
 @click.option("--output", "-o", default="",
               help="Path to where output file will be placed. Default: empty")
 @click.option("proxyhost", "--proxy-host", "-ph", multiple=False, type=str, default=None,
@@ -50,7 +52,7 @@ def cli():
               help="Proxy port number --proxy-port")
 @click.option("proxyprotocol", "--proxy-protocol", "-pr", multiple=False, type=str, default='http',
               help="Proxy protocol (https or http) --proxy-protocol")
-def check(key, db, json, full_report, bare, stdin, files, cache, ignore, output, proxyprotocol, proxyhost, proxyport):
+def check(key, db, json, full_report, bare, licenses_only, stdin, files, cache, ignore, output, proxyprotocol, proxyhost, proxyport):
     if files and stdin:
         click.secho("Can't read from --stdin and --file at the same time, exiting", fg="red", file=sys.stderr)
         sys.exit(-1)
@@ -73,12 +75,13 @@ def check(key, db, json, full_report, bare, stdin, files, cache, ignore, output,
             click.secho("Proxy Protocol should be http or https only.", fg="red")
             sys.exit(-1)
     try:
-        vulns = safety.check(packages=packages, key=key, db_mirror=db, cached=cache, ignore_ids=ignore, proxy=proxy_dictionary)
+        vulns, licenses_dict = safety.check(packages=packages, key=key, db_mirror=db, cached=cache, ignore_ids=ignore, proxy=proxy_dictionary, licenses_only=licenses_only)
         output_report = report(vulns=vulns, 
                                full=full_report, 
                                json_report=json, 
                                bare_report=bare,
-                               checked_packages=len(packages), 
+                               checked_packages=len(packages),
+                               licenses=licenses_dict,
                                db=db, 
                                key=key)
 

--- a/safety/util.py
+++ b/safety/util.py
@@ -1,5 +1,6 @@
 from dparse.parser import setuptools_parse_requirements_backport as _parse_requirements
 from collections import namedtuple
+from packaging.version import parse as parse_version
 import click
 import sys
 import json
@@ -124,3 +125,47 @@ def get_license_name_by_id(license_id, db):
         if id == license_id:
             return name
     return None
+
+def get_packages_licenses(packages, licenses_db):
+    """Get the licenses for the specified packages based on their version. 
+
+    :param packages: packages list
+    :param licenses_db: the licenses db in the raw form.
+    :return: list of objects with the packages and their respectives licenses.
+    """
+    packages_licenses_db = licenses_db.get('packages', {})
+    filtered_packages_licenses = []
+
+    for pkg in packages:
+        # Ignore recursive files not resolved
+        if isinstance(pkg, RequirementFile):
+            continue
+        # normalize the package name
+        pkg_name = pkg.key.replace("_", "-").lower()
+        # packages may have different licenses depending their version.
+        pkg_licenses = packages_licenses_db.get(pkg_name, [])
+        version_requested = parse_version(pkg.version)
+        license_id = None
+        license_name = None
+        for pkg_version in pkg_licenses:
+            license_start_version = parse_version(pkg_version['start_version'])
+            # Stops and return the previous stored license when a new
+            # license starts on a version above the requested one.
+            if version_requested >= license_start_version:
+                license_id = pkg_version['license_id']
+            else:
+                # We found the license for the version requested
+                break
+
+        if license_id:
+            license_name = get_license_name_by_id(license_id, licenses_db)
+        if not license_id or not license_name:
+            license_name = "N/A"
+
+        filtered_packages_licenses.append({
+            "package": pkg_name,
+            "version": pkg.version,
+            "license": license_name
+        })
+
+    return filtered_packages_licenses

--- a/safety/util.py
+++ b/safety/util.py
@@ -105,3 +105,22 @@ def read_requirements(fh, resolve=False):
                     )
             except ValueError:
                 continue
+
+
+def get_proxy_dict(proxyprotocol, proxyhost, proxyport):
+    proxy_dictionary = {}
+    if proxyhost is not None:
+        if proxyprotocol in ["http", "https"]:
+            proxy_dictionary = {proxyprotocol: "{0}://{1}:{2}".format(proxyprotocol, proxyhost, str(proxyport))}
+        else:
+            click.secho("Proxy Protocol should be http or https only.", fg="red")
+            sys.exit(-1)
+    return proxy_dictionary
+
+
+def get_license_name_by_id(license_id, db):
+    licenses = db.get('licenses', [])
+    for name, id in licenses.items():
+        if id == license_id:
+            return name
+    return None

--- a/tests/test_db/insecure_full.json
+++ b/tests/test_db/insecure_full.json
@@ -16,10 +16,5 @@
             "cve": "some other cve",
             "id": "some other id"
         }
-    ],
-    "$meta": {
-        "licenses": {
-            "django": "BSD-3-Clause"
-        }
-    }
+    ]
 }

--- a/tests/test_db/insecure_full.json
+++ b/tests/test_db/insecure_full.json
@@ -16,5 +16,10 @@
             "cve": "some other cve",
             "id": "some other id"
         }
-    ]
+    ],
+    "$meta": {
+        "licenses": {
+            "django": "BSD-3-Clause"
+        }
+    }
 }

--- a/tests/test_db/licenses.json
+++ b/tests/test_db/licenses.json
@@ -1,0 +1,13 @@
+{
+    "licenses": {
+        "BSD-3-Clause": 1
+    },
+    "packages": {
+        "django": [
+            {
+                "start_version": "0.0",
+                "license_id": 1
+            }
+        ]
+    }
+}

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -133,7 +133,7 @@ class TestSafety(unittest.TestCase):
         reqs = StringIO("Django==1.8.1")
         packages = util.read_requirements(reqs)
 
-        vulns, _licenses = safety.check(
+        vulns = safety.check(
             packages=packages,
             db_mirror=os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
@@ -143,7 +143,6 @@ class TestSafety(unittest.TestCase):
             key=False,
             ignore_ids=[],
             proxy={},
-            licenses_only=False,
         )
         self.assertEqual(len(vulns), 2)
 
@@ -152,7 +151,7 @@ class TestSafety(unittest.TestCase):
                          "--hash=sha256:c6c7e7a961e2847d050d214ca96dc3167bb5f2b25cd5c6cb2eea96e1717f4ade"))
         packages = util.read_requirements(reqs)
 
-        vulns, _licenses = safety.check(
+        vulns = safety.check(
             packages=packages,
             db_mirror=os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
@@ -162,7 +161,6 @@ class TestSafety(unittest.TestCase):
             key=False,
             ignore_ids=[],
             proxy={},
-            licenses_only=False,
         )
         self.assertEqual(len(vulns), 2)
 
@@ -170,7 +168,7 @@ class TestSafety(unittest.TestCase):
         reqs = StringIO("Django==1.8.1\n\rDjango==1.7.0")
         packages = util.read_requirements(reqs)
 
-        vulns, _licenses = safety.check(
+        vulns = safety.check(
             packages=packages,
             db_mirror=os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
@@ -180,7 +178,6 @@ class TestSafety(unittest.TestCase):
             key=False,
             ignore_ids=[],
             proxy={},
-            licenses_only=False,
         )
         self.assertEqual(len(vulns), 4)
 
@@ -188,14 +185,13 @@ class TestSafety(unittest.TestCase):
         reqs = StringIO("insecure-package==0.1")
         packages = util.read_requirements(reqs)
 
-        vulns, _licenses = safety.check(
+        vulns = safety.check(
             packages=packages,
             db_mirror=False,
             cached=False,
             key=False,
             ignore_ids=[],
             proxy={},
-            licenses_only=False,
         )
         self.assertEqual(len(vulns), 1)
 
@@ -203,49 +199,47 @@ class TestSafety(unittest.TestCase):
         reqs = StringIO("insecure-package==0.1")
         packages = util.read_requirements(reqs)
 
-        vulns, _licenses = safety.check(
+        vulns = safety.check(
             packages=packages,
             db_mirror=False,
             cached=True,
             key=False,
             ignore_ids=[],
             proxy={},
-            licenses_only=False,
         )
         self.assertEqual(len(vulns), 1)
 
         reqs = StringIO("insecure-package==0.1")
         packages = util.read_requirements(reqs)
         # make a second call to use the cache
-        vulns, _licenses = safety.check(
+        vulns = safety.check(
             packages=packages,
             db_mirror=False,
             cached=True,
             key=False,
             ignore_ids=[],
             proxy={},
-            licenses_only=False,
         )
         self.assertEqual(len(vulns), 1)
 
-    def test_license_get_from_file(self):
-        reqs = StringIO("django==1.8.1")
-        packages = util.read_requirements(reqs)
+    # def test_license_get_from_file(self):
+    #     reqs = StringIO("django==1.8.1")
+    #     packages = util.read_requirements(reqs)
 
-        _vulns, licenses = safety.check(
-            packages=packages,
-            db_mirror=os.path.join(
-                os.path.dirname(os.path.realpath(__file__)),
-                "test_db"
-            ),
-            cached=False,
-            key=False,
-            ignore_ids=[],
-            proxy={},
-            licenses_only=True,
-        )
-        self.assertEqual(len(licenses), 1)
-        self.assertTrue(licenses["django"])
+    #     _vulns, licenses = safety.check(
+    #         packages=packages,
+    #         db_mirror=os.path.join(
+    #             os.path.dirname(os.path.realpath(__file__)),
+    #             "test_db"
+    #         ),
+    #         cached=False,
+    #         key=False,
+    #         ignore_ids=[],
+    #         proxy={},
+    #         licenses_only=True,
+    #     )
+    #     self.assertEqual(len(licenses), 1)
+    #     self.assertTrue(licenses["django"])
 
 
 class ReadRequirementsTestCase(unittest.TestCase):

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -133,7 +133,7 @@ class TestSafety(unittest.TestCase):
         reqs = StringIO("Django==1.8.1")
         packages = util.read_requirements(reqs)
 
-        vulns = safety.check(
+        vulns, _licenses = safety.check(
             packages=packages,
             db_mirror=os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
@@ -142,7 +142,8 @@ class TestSafety(unittest.TestCase):
             cached=False,
             key=False,
             ignore_ids=[],
-            proxy={}
+            proxy={},
+            licenses_only=False,
         )
         self.assertEqual(len(vulns), 2)
 
@@ -151,7 +152,7 @@ class TestSafety(unittest.TestCase):
                          "--hash=sha256:c6c7e7a961e2847d050d214ca96dc3167bb5f2b25cd5c6cb2eea96e1717f4ade"))
         packages = util.read_requirements(reqs)
 
-        vulns = safety.check(
+        vulns, _licenses = safety.check(
             packages=packages,
             db_mirror=os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
@@ -160,7 +161,8 @@ class TestSafety(unittest.TestCase):
             cached=False,
             key=False,
             ignore_ids=[],
-            proxy={}
+            proxy={},
+            licenses_only=False,
         )
         self.assertEqual(len(vulns), 2)
 
@@ -168,7 +170,7 @@ class TestSafety(unittest.TestCase):
         reqs = StringIO("Django==1.8.1\n\rDjango==1.7.0")
         packages = util.read_requirements(reqs)
 
-        vulns = safety.check(
+        vulns, _licenses = safety.check(
             packages=packages,
             db_mirror=os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
@@ -177,7 +179,8 @@ class TestSafety(unittest.TestCase):
             cached=False,
             key=False,
             ignore_ids=[],
-            proxy={}
+            proxy={},
+            licenses_only=False,
         )
         self.assertEqual(len(vulns), 4)
 
@@ -185,13 +188,14 @@ class TestSafety(unittest.TestCase):
         reqs = StringIO("insecure-package==0.1")
         packages = util.read_requirements(reqs)
 
-        vulns = safety.check(
+        vulns, _licenses = safety.check(
             packages=packages,
             db_mirror=False,
             cached=False,
             key=False,
             ignore_ids=[],
-            proxy={}
+            proxy={},
+            licenses_only=False,
         )
         self.assertEqual(len(vulns), 1)
 
@@ -199,28 +203,49 @@ class TestSafety(unittest.TestCase):
         reqs = StringIO("insecure-package==0.1")
         packages = util.read_requirements(reqs)
 
-        vulns = safety.check(
+        vulns, _licenses = safety.check(
             packages=packages,
             db_mirror=False,
             cached=True,
             key=False,
             ignore_ids=[],
-            proxy={}
+            proxy={},
+            licenses_only=False,
         )
         self.assertEqual(len(vulns), 1)
 
         reqs = StringIO("insecure-package==0.1")
         packages = util.read_requirements(reqs)
         # make a second call to use the cache
-        vulns = safety.check(
+        vulns, _licenses = safety.check(
             packages=packages,
             db_mirror=False,
             cached=True,
             key=False,
             ignore_ids=[],
-            proxy={}
+            proxy={},
+            licenses_only=False,
         )
         self.assertEqual(len(vulns), 1)
+
+    def test_license_get_from_file(self):
+        reqs = StringIO("django==1.8.1")
+        packages = util.read_requirements(reqs)
+
+        _vulns, licenses = safety.check(
+            packages=packages,
+            db_mirror=os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                "test_db"
+            ),
+            cached=False,
+            key=False,
+            ignore_ids=[],
+            proxy={},
+            licenses_only=True,
+        )
+        self.assertEqual(len(licenses), 1)
+        self.assertTrue(licenses["django"])
 
 
 class ReadRequirementsTestCase(unittest.TestCase):


### PR DESCRIPTION
This PR will allow Safety users visualize packages licenses using the new `license` sub command when available.

e.g `safety license --no-cache --key 84567236-123ef62a-1ff87072-191a95bb -r /local/test/requirements.txt`