### PR TITLE
Change used db message when using free database

### DIFF
--- a/safety/formatter.py
+++ b/safety/formatter.py
@@ -175,11 +175,11 @@ class BareReport(object):
 
 def get_used_db(key, db):
     key = key if key else os.environ.get("SAFETY_API_KEY", False)
+    if db:
+        return "local DB"
     if key:
         return "pyup.io's DB"
-    if db == '':
-        return 'default DB'
-    return "local DB"
+    return "default DB"
 
 
 def report(vulns, full=False, json_report=False, bare_report=False, checked_packages=0, db=None, key=None):

--- a/safety/formatter.py
+++ b/safety/formatter.py
@@ -179,7 +179,7 @@ def get_used_db(key, db):
         return "local DB"
     if key:
         return "pyup.io's DB"
-    return "default DB"
+    return "free DB (updated once a month)"
 
 
 def report(vulns, full=False, json_report=False, bare_report=False, checked_packages=0, db=None, key=None):

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -70,7 +70,7 @@ class TestFormatter(unittest.TestCase):
         assert json.loads(json_report) == test_arr
 
     def test_get_used_db(self):
-        assert 'default DB' == formatter.get_used_db(key=None, db='')
+        assert 'free DB (updated once a month)' == formatter.get_used_db(key=None, db='')
         assert 'pyup.io\'s DB' == formatter.get_used_db(key='foo', db='')
         assert 'local DB' == formatter.get_used_db(key=None, db='/usr/local/some-db')
 


### PR DESCRIPTION
This will allow users to take knowledge that Safety-DB is updated once in a month.
Maybe will make sense merging #317 first.