### PR TITLE
Provide CVSS information when available.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 
 * Reduced Docker image and Binary size
 * Added bare and json outputs to license command
+* Provide CVSS scores on full report, when available
 
 1.10.0 (2020-12-20)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,12 @@
 History
 =======
 
-1.10.1 (2020-12-03)
+1.10.2 (master)
+-------------------
+
+* Provide CVSS scores on full report, when available
+
+1.10.1 (2021-01-03)
 -------------------
 
 * Reduced Docker image and Binary size

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,7 +12,6 @@ History
 
 * Reduced Docker image and Binary size
 * Added bare and json outputs to license command
-* Provide CVSS scores on full report, when available
 
 1.10.0 (2020-12-20)
 -------------------

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ ___
 
 ### `--full-report`
 
-*Full reports include a security advisory (if available).*
+*Full reports include a security advisory and CVSS scores (if available).*
 
 **Example**
 ```bash
@@ -276,6 +276,8 @@ safety check --full-report
 | REPORT                                                                       |
 +============================+===========+==========================+==========+
 | package                    | installed | affected                 | ID       |
++============================+===========+==========================+==========+
+| CVSS v2 | BASE SCORE: 6.5 | IMPACT SCORE: 6.4                                |
 +============================+===========+==========================+==========+
 | django                     | 1.2       | <1.2.2                   | 25701    |
 +==============================================================================+

--- a/safety/cli.py
+++ b/safety/cli.py
@@ -31,6 +31,8 @@ def cli():
 @click.option("--full-report/--short-report", default=False,
               help='Full reports include a security advisory (if available). Default: '
                    '--short-report')
+# @click.option("--cvss", default="",
+#               help="Extend reports with premium CVSS information (if available). Default: empty")
 @click.option("--bare/--not-bare", default=False,
               help='Output vulnerable packages only. '
                    'Useful in combination with other tools. '

--- a/safety/cli.py
+++ b/safety/cli.py
@@ -31,8 +31,6 @@ def cli():
 @click.option("--full-report/--short-report", default=False,
               help='Full reports include a security advisory (if available). Default: '
                    '--short-report')
-# @click.option("--cvss", default="",
-#               help="Extend reports with premium CVSS information (if available). Default: empty")
 @click.option("--bare/--not-bare", default=False,
               help='Output vulnerable packages only. '
                    'Useful in combination with other tools. '

--- a/safety/formatter.py
+++ b/safety/formatter.py
@@ -114,7 +114,10 @@ class SheetReport(object):
                         impact_score = vuln.cvssv2.get("impact_score", "None")
 
                         table.append("| {:76} |".format(
-                            f"CVSS v2 | BASE SCORE: {base_score} | IMPACT SCORE: {impact_score}"
+                            "CVSS v2 | BASE SCORE: {} | IMPACT SCORE: {}".format(
+                                base_score,
+                                impact_score,
+                            )
                         ))
                         table.append(SheetReport.REPORT_SECTION)
 
@@ -124,7 +127,11 @@ class SheetReport(object):
                         base_severity = vuln.cvssv3.get("base_severity", "None")
 
                         table.append("| {:76} |".format(
-                            f"CVSS v3 | BASE SCORE: {base_score} | IMPACT SCORE: {impact_score} | BASE SEVERITY: {base_severity}"
+                            "CVSS v3 | BASE SCORE: {} | IMPACT SCORE: {} | BASE SEVERITY: {}".format(
+                                base_score,
+                                impact_score,
+                                base_severity,
+                            )
                         ))
                         table.append(SheetReport.REPORT_SECTION)
 
@@ -226,18 +233,21 @@ class BasicReport(object):
                         base_score = vuln.cvssv2.get("base_score", "None")
                         impact_score = vuln.cvssv2.get("impact_score", "None")
 
-                        table.append(
-                            f"CVSS v2 -- BASE SCORE: {base_score}, IMPACT SCORE: {impact_score}"
-                        )
+                        table.append("CVSS v2 -- BASE SCORE: {}, IMPACT SCORE: {}".format(
+                            base_score,
+                            impact_score,
+                        ))
 
                     if vuln.cvssv3 is not None:
                         base_score = vuln.cvssv3.get("base_score", "None")
                         impact_score = vuln.cvssv3.get("impact_score", "None")
                         base_severity = vuln.cvssv3.get("base_severity", "None")
 
-                        table.append(
-                            f"CVSS v3 -- BASE SCORE: {base_score}, IMPACT SCORE: {impact_score}, BASE SEVERITY: {base_severity}"
-                        )
+                        table.append("CVSS v3 -- BASE SCORE: {}, IMPACT SCORE: {}, BASE SEVERITY: {}".format(
+                            base_score,
+                            impact_score,
+                            base_severity,
+                        ))
 
                     table.append(get_advisory(vuln))
                     table.append("--")

--- a/safety/formatter.py
+++ b/safety/formatter.py
@@ -109,6 +109,25 @@ class SheetReport(object):
                 if full:
                     table.append(SheetReport.REPORT_SECTION)
 
+                    if vuln.cvssv2 is not None:
+                        base_score = vuln.cvssv2.get("base_score", "None")
+                        impact_score = vuln.cvssv2.get("impact_score", "None")
+
+                        table.append("| {:76} |".format(
+                            f"CVSS v2 | BASE SCORE: {base_score} | IMPACT SCORE: {impact_score}"
+                        ))
+                        table.append(SheetReport.REPORT_SECTION)
+
+                    if vuln.cvssv3 is not None:
+                        base_score = vuln.cvssv3.get("base_score", "None")
+                        impact_score = vuln.cvssv3.get("impact_score", "None")
+                        base_severity = vuln.cvssv3.get("base_severity", "None")
+
+                        table.append("| {:76} |".format(
+                            f"CVSS v3 | BASE SCORE: {base_score} | IMPACT SCORE: {impact_score} | BASE SEVERITY: {base_severity}"
+                        ))
+                        table.append(SheetReport.REPORT_SECTION)
+
                     descr = get_advisory(vuln)
 
                     for pn, paragraph in enumerate(descr.replace('\r', '').split('\n\n')):
@@ -203,6 +222,23 @@ class BasicReport(object):
                     vuln.vuln_id
                 ))
                 if full:
+                    if vuln.cvssv2 is not None:
+                        base_score = vuln.cvssv2.get("base_score", "None")
+                        impact_score = vuln.cvssv2.get("impact_score", "None")
+
+                        table.append(
+                            f"CVSS v2 -- BASE SCORE: {base_score}, IMPACT SCORE: {impact_score}"
+                        )
+
+                    if vuln.cvssv3 is not None:
+                        base_score = vuln.cvssv3.get("base_score", "None")
+                        impact_score = vuln.cvssv3.get("impact_score", "None")
+                        base_severity = vuln.cvssv3.get("base_severity", "None")
+
+                        table.append(
+                            f"CVSS v3 -- BASE SCORE: {base_score}, IMPACT SCORE: {impact_score}, BASE SEVERITY: {base_severity}"
+                        )
+
                     table.append(get_advisory(vuln))
                     table.append("--")
         else:

--- a/safety/safety.py
+++ b/safety/safety.py
@@ -161,6 +161,7 @@ def check(packages, key, db_mirror, cached, ignore_ids, proxy):
                         if cve_id:
                             cve_id = cve_id.split(",")[0].strip()
                         if vuln_id and vuln_id not in ignore_ids:
+                            cve_meta = db_full.get("$meta", {}).get("cve", {}).get(cve_id, {})
                             vulnerable.append(
                                 Vulnerability(
                                     name=name,
@@ -168,8 +169,8 @@ def check(packages, key, db_mirror, cached, ignore_ids, proxy):
                                     version=pkg.version,
                                     advisory=data.get("advisory"),
                                     vuln_id=vuln_id,
-                                    cvssv2=db_full.get("$meta", {}).get("cve", {}).get(cve_id, {}).get("cvssv2", None),
-                                    cvssv3=db_full.get("$meta", {}).get("cve", {}).get(cve_id, {}).get("cvssv3", None)
+                                    cvssv2=cve_meta.get("cvssv2", None),
+                                    cvssv3=cve_meta.get("cvssv3", None)
                                 )
                             )
     return vulnerable

--- a/safety/safety.py
+++ b/safety/safety.py
@@ -107,7 +107,7 @@ def fetch_database_file(path, db_name):
         return json.loads(f.read())
 
 
-def fetch_database(full=False, premium=False, key=False, db=False, cached=False, proxy={}):
+def fetch_database(full=False, key=False, db=False, cached=False, proxy={}):
 
     if db:
         mirrors = [db]
@@ -115,7 +115,6 @@ def fetch_database(full=False, premium=False, key=False, db=False, cached=False,
         mirrors = API_MIRRORS if key else OPEN_MIRRORS
 
     db_name = "insecure_full.json" if full else "insecure.json"
-    db_name = "insecure_premium.json" if premium else db_name
     for mirror in mirrors:
         # mirror can either be a local path or a URL
         if mirror.startswith("http://") or mirror.startswith("https://"):
@@ -155,10 +154,7 @@ def check(packages, key, db_mirror, cached, ignore_ids, proxy):
                 spec_set = SpecifierSet(specifiers=specifier)
                 if spec_set.contains(pkg.version):
                     if not db_full:
-                        try:
-                            db_full = fetch_database(full=True, premium=True, key=key, db=db_mirror, cached=cached, proxy=proxy)
-                        except:
-                            db_full = fetch_database(full=True, key=key, db=db_mirror, cached=cached, proxy=proxy)
+                        db_full = fetch_database(full=True, key=key, db=db_mirror, cached=cached, proxy=proxy)
                     for data in get_vulnerabilities(pkg=name, spec=specifier, db=db_full):
                         vuln_id = data.get("id").replace("pyup.io-", "")
                         cve_id = data.get("cve")

--- a/safety/safety.py
+++ b/safety/safety.py
@@ -170,7 +170,7 @@ def check(packages, key, db_mirror, cached, ignore_ids, proxy):
                                     advisory=data.get("advisory"),
                                     vuln_id=vuln_id,
                                     cvssv2=cve_meta.get("cvssv2", None),
-                                    cvssv3=cve_meta.get("cvssv3", None)
+                                    cvssv3=cve_meta.get("cvssv3", None),
                                 )
                             )
     return vulnerable

--- a/safety/safety.py
+++ b/safety/safety.py
@@ -107,7 +107,7 @@ def fetch_database_file(path, db_name):
         return json.loads(f.read())
 
 
-def fetch_database(full=False, key=False, db=False, cached=False, proxy={}):
+def fetch_database(full=False, premium=False, key=False, db=False, cached=False, proxy={}):
 
     if db:
         mirrors = [db]
@@ -115,6 +115,7 @@ def fetch_database(full=False, key=False, db=False, cached=False, proxy={}):
         mirrors = API_MIRRORS if key else OPEN_MIRRORS
 
     db_name = "insecure_full.json" if full else "insecure.json"
+    db_name = "insecure_premium.json" if premium else db_name
     for mirror in mirrors:
         # mirror can either be a local path or a URL
         if mirror.startswith("http://") or mirror.startswith("https://"):
@@ -137,6 +138,7 @@ def check(packages, key, db_mirror, cached, ignore_ids, proxy):
     key = key if key else os.environ.get("SAFETY_API_KEY", False)
     db = fetch_database(key=key, db=db_mirror, cached=cached, proxy=proxy)
     db_full = None
+    premium = False
     vulnerable_packages = frozenset(db.keys())
     vulnerable = []
     for pkg in packages:
@@ -154,9 +156,14 @@ def check(packages, key, db_mirror, cached, ignore_ids, proxy):
                 spec_set = SpecifierSet(specifiers=specifier)
                 if spec_set.contains(pkg.version):
                     if not db_full:
-                        db_full = fetch_database(full=True, key=key, db=db_mirror, cached=cached, proxy=proxy)
+                        premium = True
+                        db_full = fetch_database(full=True, premium=True, key=key, db=db_mirror, cached=cached, proxy=proxy)
+                        if not db_full:
+                            premium = False
+                            db_full = fetch_database(full=True, key=key, db=db_mirror, cached=cached, proxy=proxy)
                     for data in get_vulnerabilities(pkg=name, spec=specifier, db=db_full):
                         vuln_id = data.get("id").replace("pyup.io-", "")
+                        cve_ids = map(str.strip, data.get("cve").split(','))
                         if vuln_id and vuln_id not in ignore_ids:
                             vulnerable.append(
                                 Vulnerability(

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -121,6 +121,8 @@ class TestFormatter(unittest.TestCase):
                          + ' blah' * 15 + '.\r\n\r\n'
                          + 'All users are urged to upgrade please.\r\n',
                 vuln_id=1234,
+                cvssv2=None,
+                cvssv3=None,
             ),
         ]
         full_report = formatter.SheetReport.render(


### PR DESCRIPTION
This will allow Safety-CLI users to have access when CVSS information is available on meta.

And only visible when using `--full-report`. Here some example (not a real vuln):

![Screenshot from 2020-11-22 19-42-17](https://user-images.githubusercontent.com/15098085/99919220-e5931580-2cfa-11eb-8092-00009a03de8e.png)
