### PR TITLE
MacOS AppVeyor Python Binary

### DIFF
--- a/appveyor.py
+++ b/appveyor.py
@@ -46,7 +46,7 @@ class environment:
         MACOS: {
             # On macOS the binary is built using Python 3.7 (Homebrew), because
             # the shipped Python lacks libraries PyInstaller needs.
-            64: "/usr/local/bin/python3",
+            64: "/usr/local/bin/python",
         }
     }
 

--- a/appveyor.py
+++ b/appveyor.py
@@ -44,9 +44,9 @@ class environment:
         ]),
 
         MACOS: {
-            # On macOS the binary is built using Python 3.7 (Homebrew), because
-            # the shipped Python lacks libraries PyInstaller needs.
-            64: "/usr/local/bin/python",
+            # Trying to use Python 3 compatible with PyInstaller according
+            # https://www.appveyor.com/docs/macos-images-software/#python
+            64: "~/venv3.8/bin/python",
         }
     }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ skip_branch_with_pr: true
 branches:
   only:
     - master
+    - appveyor-fixes
     - /\d*\.\d*\.\d*/
 
 # note: on macOS the binary is built using Python 3.7 (installed via Homebrew), because


### PR DESCRIPTION
We have some issues building MacOS binary through AppVeyor. This pull-request tries to use proper Python executable to get the build finishing with success.