### PR TITLE
Fix a missing space in help message of bare option

### DIFF
--- a/safety/cli.py
+++ b/safety/cli.py
@@ -102,7 +102,7 @@ def check(key, db, json, full_report, bare, stdin, files, cache, ignore, output,
               help='Full reports include a security advisory (if available). Default: '
                    '--short-report')
 @click.option("--bare/--not-bare", default=False,
-              help='Output vulnerable packages only. Useful in combination with other tools.'
+              help='Output vulnerable packages only. Useful in combination with other tools. '
                    'Default: --not-bare')
 @click.option("file", "--file", "-f", type=click.File(), required=True,
               help="Read input from an insecure report file. Default: empty")


### PR DESCRIPTION
A space seem to be missed in the help message.

```
  --bare / --not-bare             Output vulnerable packages only. Useful in
                                  combination with other tools.Default: --not-
                                  bare
```

```
$ safety check --help
Usage: safety check [OPTIONS]

Options:
  --key TEXT                      API Key for pyup.io's vulnerability
                                  database. Can be set as SAFETY_API_KEY
                                  environment variable. Default: empty

  --db TEXT                       Path to a local vulnerability database.
                                  Default: empty

  --json / --no-json              Output vulnerabilities in JSON format.
                                  Default: --no-json

  --full-report / --short-report  Full reports include a security advisory (if
                                  available). Default: --short-report

  --bare / --not-bare             Output vulnerable packages only. Useful in
                                  combination with other tools.Default: --not-
                                  bare
.
.
.
```