### PR TITLE
Replace ADD with COPY instruction in Dockerfile

### DIFF
--- a/Dockerfilei386
+++ b/Dockerfilei386
@@ -17,7 +17,7 @@ RUN python3 -m pip install pyinstaller pytest
 
 RUN mkdir /app
 WORKDIR /app
-ADD . ./
+COPY . ./
 
 # Install this project dependencies
 RUN python3 -m pip install -e .


### PR DESCRIPTION
Reference:

- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy

> For other items (files, directories) that do not require `ADD`’s
> tar auto-extraction capability, you should always use `COPY`.