### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ safety check -i 1234 -i 4567 -i 89101
 safety check -o insecure_report.txt
 ```
 ```bash
-safety check --output --json insecure_report.json
+safety check --json --output insecure_report.json
 ```
 ___
 


### PR DESCRIPTION
If you attempt to run the command `safety check --output --json insecure_report.json` given in the README it fails due to `--output` expecting a filename where --json is then given and insecure_report.json is now an unknown parameter. Running the --json flag first then --output with insecure_report.json allows the command to run correctly.