### PR TITLE
Update docker file to use the latest python image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM python:3.6-slim
+FROM python:3-slim
 RUN pip install --trusted-host pypi.python.org safety
 CMD ["python"]


### PR DESCRIPTION
cf #304 
Use the 3-slim rolling tag instead of using a fixed python version.