### PR TITLE
Adding support for an "ignore file" Issue #351

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![Travis](https://img.shields.io/travis/pyupio/safety.svg)](https://travis-ci.org/pyupio/safety)
 [![Updates](https://pyup.io/repos/github/pyupio/safety/shield.svg)](https://pyup.io/repos/github/pyupio/safety/)
 
-Safety checks your installed dependencies for known security vulnerabilities. 
+Safety checks your installed dependencies for known security vulnerabilities.
 
-By default it uses the open Python vulnerability database [Safety DB](https://github.com/pyupio/safety-db), 
-but can be upgraded to use pyup.io's [Safety API](https://github.com/pyupio/safety/blob/master/docs/api_key.md) using the `--key` option. 
+By default it uses the open Python vulnerability database [Safety DB](https://github.com/pyupio/safety-db),
+but can be upgraded to use pyup.io's [Safety API](https://github.com/pyupio/safety/blob/master/docs/api_key.md) using the `--key` option.
 
 # Installation
 
@@ -140,7 +140,7 @@ of Safety.
 
 ## Using Safety with a CI service
 
-Safety works great in your CI pipeline. It returns a non-zero exit status if it finds a vulnerability. 
+Safety works great in your CI pipeline. It returns a non-zero exit status if it finds a vulnerability.
 
 Run it before or after your tests. If Safety finds something, your tests will fail.
 
@@ -177,9 +177,9 @@ commands =
 
 **Deep GitHub Integration**
 
-If you are looking for a deep integration with your GitHub repositories: Safety is available as a 
-part of [pyup.io](https://pyup.io/), called [Safety CI](https://pyup.io/safety/ci/). Safety CI 
-checks your commits and pull requests for dependencies with known security vulnerabilities 
+If you are looking for a deep integration with your GitHub repositories: Safety is available as a
+part of [pyup.io](https://pyup.io/), called [Safety CI](https://pyup.io/safety/ci/). Safety CI
+checks your commits and pull requests for dependencies with known security vulnerabilities
 and displays a status on GitHub.
 
 ![Safety CI](https://github.com/pyupio/safety/raw/master/safety_ci.png)
@@ -357,6 +357,45 @@ safety check --ignore=1234
 ```
 ```bash
 safety check -i 1234 -i 4567 -i 89101
+```
+
+---
+
+### `--ignore-file`, `-f`
+
+*Read list from file of vulnerability IDs that will be ignored
+
+**Example**
+```bash
+safety check -f dependencies.ignore
+```
+```bash
+safety check --ignore-file dependencies.ignore
+```
+
+The ignore file should be in the format:
+```
+ID YYYY-MM-DD # comment
+```
+* The ID is the vulerability ID number
+* YYYY-MM-DD is an optional expiration date after which the vulerability will no longer be ignored
+* You can end each line with an optional comment
+
+You may also have lines that consisten only of comments.  Here is an example ignore file:
+```
+# Any  vulnerability ID numbers listed in this file will be ignored when
+# running the safety dependency check. Each line should have the ID number
+# and a date. The ID will be ignored by the CI pipeline check unitl the date
+# in YYYY-MM-DD format listed for that line.
+# If no date is listed, the exception will never expire. (NOT RECOMMENDED)
+#
+# test
+# Example:
+# 40104 2022-01-15
+#
+40105 2022-01-15  # gunicorn vulnerability
+40104
+1234 1999-10-15 # this entry is expired and will not be ignored
 ```
 
 ### `--output`, `-o`
@@ -537,7 +576,7 @@ ___
 
 *Proxy host IP or DNS*
 
-### `--proxy-port`, `-pp` 
+### `--proxy-port`, `-pp`
 
 *Proxy port number*
 

--- a/safety/cli.py
+++ b/safety/cli.py
@@ -43,6 +43,8 @@ def cli():
               help="Read input from one (or multiple) requirement files. Default: empty")
 @click.option("ignore", "--ignore", "-i", multiple=True, type=str, default=[],
               help="Ignore one (or multiple) vulnerabilities by ID. Default: empty")
+@click.option("ignorefile", "--ignore-file", "-f", multiple=False, type=click.File(), default=None,
+              help="File with a list of vulnerability IDs to ignore.  Default: None")
 @click.option("--output", "-o", default="",
               help="Path to where output file will be placed. Default: empty")
 @click.option("proxyhost", "--proxy-host", "-ph", multiple=False, type=str, default=None,
@@ -51,7 +53,7 @@ def cli():
               help="Proxy port number --proxy-port")
 @click.option("proxyprotocol", "--proxy-protocol", "-pr", multiple=False, type=str, default='http',
               help="Proxy protocol (https or http) --proxy-protocol")
-def check(key, db, json, full_report, bare, stdin, files, cache, ignore, output, proxyprotocol, proxyhost, proxyport):
+def check(key, db, json, full_report, bare, stdin, files, cache, ignore, ignorefile, output, proxyprotocol, proxyhost, proxyport):
     if files and stdin:
         click.secho("Can't read from --stdin and --file at the same time, exiting", fg="red", file=sys.stderr)
         sys.exit(-1)
@@ -65,16 +67,16 @@ def check(key, db, json, full_report, bare, stdin, files, cache, ignore, output,
         packages = [
             d for d in pkg_resources.working_set
             if d.key not in {"python", "wsgiref", "argparse"}
-        ]    
+        ]
     proxy_dictionary = get_proxy_dict(proxyprotocol, proxyhost, proxyport)
     try:
         vulns = safety.check(packages=packages, key=key, db_mirror=db, cached=cache, ignore_ids=ignore, proxy=proxy_dictionary)
-        output_report = report(vulns=vulns, 
-                               full=full_report, 
-                               json_report=json, 
+        output_report = report(vulns=vulns,
+                               full=full_report,
+                               json_report=json,
                                bare_report=bare,
                                checked_packages=len(packages),
-                               db=db, 
+                               db=db,
                                key=key)
 
         if output:
@@ -154,15 +156,15 @@ def license(key, db, json, bare, cache, files, proxyprotocol, proxyhost, proxypo
         packages = [
             d for d in pkg_resources.working_set
             if d.key not in {"python", "wsgiref", "argparse"}
-        ]  
-   
+        ]
+
     proxy_dictionary = get_proxy_dict(proxyprotocol, proxyhost, proxyport)
     try:
         licenses_db = safety.get_licenses(key, db, cache, proxy_dictionary)
     except InvalidKeyError as invalid_key_error:
         if str(invalid_key_error):
             message = str(invalid_key_error)
-        else: 
+        else:
             message = "Your API Key '{key}' is invalid. See {link}".format(
                 key=key, link='https://goo.gl/O7Y1rS'
             )


### PR DESCRIPTION
Here is a first draft of an implementation of an "ignore file"
The ignore file consists of lines with vulnerability IDs  followed optionally by an expiration date after which the vulnerability will no longer be ignored.  It also supports comments in the file using a # mark.  The command line option is -f or --ignore-file.
Additional details are in the update I made to the README.md.

My apologies for modifying the whitespace in a few lines. That was done by my editor and I didn't realize it until after the commit.

