### PR TITLE
Safety support as a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Travis](https://img.shields.io/travis/pyupio/safety.svg)](https://travis-ci.org/pyupio/safety)
 [![Updates](https://pyup.io/repos/github/pyupio/safety/shield.svg)](https://pyup.io/repos/github/pyupio/safety/)
 
-Safety checks your installed Python dependencies for known security vulnerabilities and suggests the proper remediations for vulnerabilities detected. Safety can be run on developer machines, in CI/CD pipelines and on production systems.
+Safety checks Python dependencies for known security vulnerabilities and suggests the proper remediations for vulnerabilities detected. Safety can be run on developer machines, in CI/CD pipelines and on production systems.
 
 By default it uses the open Python vulnerability database [Safety DB](https://github.com/pyupio/safety-db), which is **licensed for non-commercial use only**.
 

--- a/safety/cli.py
+++ b/safety/cli.py
@@ -55,18 +55,19 @@ def cli(ctx, debug, telemetry):
 @click.option("--cache", is_flag=False, flag_value=60, default=0,
               help="Cache requests to the vulnerability database locally. Default: 0 seconds",
               hidden=True)
-@click.option("--stdin/--no-stdin", default=False, cls=MutuallyExclusiveOption, mutually_exclusive=["files"],
-              help="Read input from stdin. Default: --no-stdin")
-@click.option("files", "--file", "-r", multiple=True, type=click.File(), cls=MutuallyExclusiveOption, mutually_exclusive=["stdin"],
+@click.option("--stdin", default=False, cls=MutuallyExclusiveOption, mutually_exclusive=["files"],
+              help="Read input from stdin.", is_flag=True, show_default=True)
+@click.option("files", "--file", "-r", multiple=True, type=click.File(), cls=MutuallyExclusiveOption,
+              mutually_exclusive=["stdin"],
               help="Read input from one (or multiple) requirement files. Default: empty")
 @click.option("--ignore", "-i", multiple=True, type=str, default=[], callback=transform_ignore,
               help="Ignore one (or multiple) vulnerabilities by ID. Default: empty")
-@click.option('--json/--no-json', default=False, cls=MutuallyExclusiveOption, mutually_exclusive=["output", "bare"],
+@click.option('--json', default=False, cls=MutuallyExclusiveOption, mutually_exclusive=["output", "bare"],
               with_values={"output": ['screen', 'text', 'bare', 'json'], "bare": [True, False]}, callback=json_alias,
-              hidden=True)
-@click.option('--bare/--not-bare', default=False, cls=MutuallyExclusiveOption, mutually_exclusive=["output", "json"],
+              hidden=True, is_flag=True, show_default=True)
+@click.option('--bare', default=False, cls=MutuallyExclusiveOption, mutually_exclusive=["output", "json"],
               with_values={"output": ['screen', 'text', 'bare', 'json'], "json": [True, False]}, callback=bare_alias,
-              hidden=True)
+              hidden=True, is_flag=True, show_default=True)
 @click.option('--output', "-o", type=click.Choice(['screen', 'text', 'json', 'bare'], case_sensitive=False),
               default='screen', callback=active_color_if_needed, envvar='SAFETY_OUTPUT')
 @click.option("--proxy-protocol", "-pr", type=click.Choice(['http', 'https']), default='https', cls=DependentOption, required_options=['proxy_host'],

--- a/tests/test_output_utils.py
+++ b/tests/test_output_utils.py
@@ -17,7 +17,6 @@ class TestOutputUtils(unittest.TestCase):
     def setUp(self) -> None:
         self.maxDiff = None
 
-    @patch.object(click, 'get_current_context', Mock(params=Mock(key=Mock(return_value='foobar'))))
     def test_format_vulnerability(self):
         numpy_pkg = {'name': 'numpy', 'version': '1.22.0', 'secure_versions': ['1.22.3'],
                      'insecure_versions': ['1.22.2', '1.22.1', '1.22.0', '1.22.0rc3', '1.21.5']}
@@ -57,7 +56,6 @@ class TestOutputUtils(unittest.TestCase):
         EXPECTED = '\n'.join(lines)
         self.assertEqual(output, EXPECTED)
 
-    @patch.object(click, 'get_current_context', Mock(params=Mock(key=Mock(return_value='foobar'))))
     def test_format_vulnerability_with_ignored_vulnerability(self):
         numpy_pkg = {'name': 'numpy', 'version': '1.22.0', 'secure_versions': ['1.22.3'],
                      'insecure_versions': ['1.22.2', '1.22.1', '1.22.0', '1.22.0rc3', '1.21.5']}
@@ -117,9 +115,9 @@ class TestOutputUtils(unittest.TestCase):
         EXPECTED = '\n'.join(lines)
         self.assertEqual(output, EXPECTED)
 
-    @patch("safety.output_utils.click.get_current_context")
+    @patch("safety.output_utils.SafetyContext")
     def test_get_printable_list_of_scanned_items_stdin(self, ctx):
-        ctx.return_value = Mock(obj=[])
+        ctx.return_value = Mock(packages=[])
         output = get_printable_list_of_scanned_items('stdin')
 
         EXPECTED = (
@@ -131,7 +129,7 @@ class TestOutputUtils(unittest.TestCase):
         p_kwargs = {'name': 'django', 'version': '2.2', 'found': '/site-packages/django', 'insecure_versions': [],
                     'secure_versions': ['2.2'], 'latest_version_without_known_vulnerabilities': '2.2',
                     'latest_version': '2.2', 'more_info_url': 'https://pyup.io/package/foo'}
-        ctx.return_value = Mock(obj=[Package(**p_kwargs)])
+        ctx.return_value = Mock(packages=[Package(**p_kwargs)])
         output = get_printable_list_of_scanned_items('stdin')
 
         EXPECTED = (
@@ -140,9 +138,9 @@ class TestOutputUtils(unittest.TestCase):
 
         self.assertTupleEqual(output, EXPECTED)
 
-    @patch("safety.output_utils.click.get_current_context")
+    @patch("safety.output_utils.SafetyContext")
     def test_get_printable_list_of_scanned_items_environment(self, ctx):
-        ctx.return_value = Mock(obj=[])
+        ctx.return_value = Mock(packages=[])
         output = get_printable_list_of_scanned_items('environment')
 
         no_locations = 'No locations found in the environment'
@@ -153,7 +151,7 @@ class TestOutputUtils(unittest.TestCase):
 
         self.assertTupleEqual(output, EXPECTED)
 
-    @patch("safety.output_utils.click.get_current_context")
+    @patch("safety.output_utils.SafetyContext")
     def test_get_printable_list_of_scanned_items_files(self, ctx):
         dirname = os.path.dirname(__file__)
         file_a = open(os.path.join(dirname, "reqs_1.txt"), mode='r')
@@ -170,7 +168,7 @@ class TestOutputUtils(unittest.TestCase):
 
         self.assertTupleEqual(output, EXPECTED)
 
-    @patch("safety.output_utils.click.get_current_context")
+    @patch("safety.output_utils.SafetyContext")
     def test_get_printable_list_of_scanned_items_file(self, ctx):
         # Used by the review command
         report = open(os.path.join(

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -28,6 +28,7 @@ from safety.formatter import SafetyFormatter
 from safety.models import CVE
 from safety.safety import ignore_vuln_if_needed, get_closest_ver, precompute_remediations, compute_sec_ver, \
     calculate_remediations, read_vulnerabilities
+from safety.util import SafetyContext
 from tests.resources import VALID_REPORT, VULNS, SCANNED_PACKAGES, REMEDIATIONS
 from tests.test_cli import get_vulnerability
 
@@ -643,14 +644,12 @@ class TestSafety(unittest.TestCase):
         with open(os.path.join(self.dirname, "test_db", "report.json")) as f:
             self.assertDictEqual(self.report, read_vulnerabilities(f))
 
-    @patch.object(click, 'get_current_context', Mock())
     def test_review_without_recommended_fix(self):
         vulns, remediations, packages = safety.review(self.report)
-        self.assertDictEqual(packages, self.report_packages)
+        self.assertListEqual(packages, list(self.report_packages.values()))
         self.assertDictEqual(remediations, self.report_remediations)
         self.assertListEqual(vulns, self.report_vulns)
 
-    @patch.object(click, 'get_current_context', Mock())
     def test_report_with_recommended_fix(self):
         REMEDIATIONS_WITH_FIX = {'django': {'version': '4.0.1', 'vulns_found': 4, 'secure_versions': ['2.2.28', '3.2.13', '4.0.4'],
                                             'closest_secure_version': {'major': parse('4.0.4'),


### PR DESCRIPTION
This PR removes the heavy use of the click context; now, Safety can be used in non-CLI environments.

Other fixes:

- Documentation improvement in the help section for each command
- Fixed issue in the review command