### PR TITLE
Safety 2.x fails when git is not installed

### DIFF
--- a/safety/util.py
+++ b/safety/util.py
@@ -213,7 +213,10 @@ def build_telemetry_data(telemetry=True):
 def build_git_data():
     import subprocess
 
-    is_git = subprocess.run(["git", "rev-parse", "--is-inside-work-tree"], stdout=subprocess.PIPE).stdout.decode('utf-8').strip()
+    try:
+        is_git = subprocess.run(["git", "rev-parse", "--is-inside-work-tree"], stdout=subprocess.PIPE).stdout.decode('utf-8').strip()
+    except Exception:
+        is_git = False
 
     if is_git == "true":
         result = {


### PR DESCRIPTION
Thanks for safety!

I get the following error running safety 2.x:

```
FileNotFoundError: [Errno 2] No such file or directory: 'git'
Unhandled exception happened: [Errno 2] No such file or directory: 'git'
```

It looks like Safety 2.x introduces some checks to see if this is in a git repo. This check fails when the git binary is unavailable (eg. running safety against a dockerised application).

Reproduce the issue by running safety when `git` is not in the path eg.

```
python -m venv .venv
. .venv/bin/activate
pip install safety
PATH="`pwd`.venv/bin" safety check
```