### PR TITLE
Eat stderr messages from git commands.

### DIFF
--- a/safety/util.py
+++ b/safety/util.py
@@ -213,8 +213,11 @@ def build_telemetry_data(telemetry=True):
 def build_git_data():
     import subprocess
 
+    def git_command(commandline):
+        return subprocess.run(commandline, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL).stdout.decode('utf-8').strip()
+
     try:
-        is_git = subprocess.run(["git", "rev-parse", "--is-inside-work-tree"], stdout=subprocess.PIPE).stdout.decode('utf-8').strip()
+        is_git = git_command(["git", "rev-parse", "--is-inside-work-tree"])
     except Exception:
         is_git = False
 
@@ -228,14 +231,14 @@ def build_git_data():
         }
 
         try:
-            result['branch'] = subprocess.run(["git", "symbolic-ref", "--short", "-q", "HEAD"], stdout=subprocess.PIPE).stdout.decode('utf-8').strip()
-            result['tag'] = subprocess.run(["git", "describe", "--tags", "--exact-match"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL).stdout.decode('utf-8').strip()
+            result['branch'] = git_command(["git", "symbolic-ref", "--short", "-q", "HEAD"])
+            result['tag'] = git_command(["git", "describe", "--tags", "--exact-match"])
 
-            commit = subprocess.run(["git", "describe", '--match=""', '--always', '--abbrev=40', '--dirty'], stdout=subprocess.PIPE).stdout.decode('utf-8').strip()
+            commit = git_command(["git", "describe", '--match=""', '--always', '--abbrev=40', '--dirty'])
             result['dirty'] = commit.endswith('-dirty')
             result['commit'] = commit.split("-dirty")[0]
 
-            result['origin'] = subprocess.run(["git", "remote", "get-url", "origin"], stdout=subprocess.PIPE).stdout.decode('utf-8').strip()
+            result['origin'] = git_command(["git", "remote", "get-url", "origin"])
         except Exception:
             pass
 

--- a/safety/util.py
+++ b/safety/util.py
@@ -15,7 +15,6 @@ from packaging.utils import canonicalize_name
 from packaging.version import parse as parse_version
 from ruamel.yaml import YAML
 from ruamel.yaml.error import MarkedYAMLError
-import safety
 
 from safety.constants import EXIT_CODE_FAILURE, EXIT_CODE_OK
 from safety.models import Package, RequirementFile


### PR DESCRIPTION
Prevents "fatal: not a git repository (or any of the parent directories): .git" in cases where safety is ran outside a git repository.