### PR TITLE
Pin packaging to a compatible version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: main
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [ push ]
 
 jobs:
     test:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         strategy:
             matrix:
                 python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11" ]
@@ -32,7 +32,7 @@ jobs:
 
         strategy:
             matrix:
-                os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+                os: ['windows-latest', 'ubuntu-20.04', 'macos-latest']
         env:
             BINARY_OS: '${{ matrix.os }}'
         steps:
@@ -60,13 +60,13 @@ jobs:
                   path: dist/safety-win-x86_64.exe
                   if-no-files-found: error
             - uses: actions/upload-artifact@v3
-              if: ${{ matrix.os == 'ubuntu-latest' }}
+              if: ${{ matrix.os == 'ubuntu-20.04' }}
               with:
                   name: safety-linux-i686
                   path: dist/safety-linux-i686
                   if-no-files-found: error
             - uses: actions/upload-artifact@v3
-              if: ${{ matrix.os == 'ubuntu-latest' }}
+              if: ${{ matrix.os == 'ubuntu-20.04' }}
               with:
                   name: safety-linux-x86_64
                   path: dist/safety-linux-x86_64
@@ -81,7 +81,7 @@ jobs:
 
     deploy-pypi:
         needs: build-binaries
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
 
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
@@ -105,7 +105,7 @@ jobs:
 
     create-gh-release:
         needs: deploy-pypi
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         permissions:
             contents: write

--- a/.github/workflows/test-insecure.yml
+++ b/.github/workflows/test-insecure.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -24,7 +24,7 @@ jobs:
   # case, to avoid confusion
   test-auto-requirements-txt-insecure:
     needs: [ matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: main
     strategy:
       matrix:
@@ -49,7 +49,7 @@ jobs:
   # Same as above, but for a poetry lock file
   test-auto-poetry-insecure:
     needs: [ matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: main
     strategy:
       matrix:
@@ -74,7 +74,7 @@ jobs:
   # Same as above, but for a Pipfile.lock
   test-auto-pipfile-insecure:
     needs: [ matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: main
     strategy:
       matrix:
@@ -101,7 +101,7 @@ jobs:
   ### installs things in the root VM that the action runs on; this is what gets scanned.
   test-auto-environment-insecure:
     needs: [ matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: main
     strategy:
       matrix:
@@ -132,7 +132,7 @@ jobs:
   ### Scans a recently built Docker container. This uses a few heuristics, defined in entrypoint.sh
   test-auto-docker-insecure:
     needs: [ matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: main
     strategy:
       matrix:

--- a/.github/workflows/test-secure.yml
+++ b/.github/workflows/test-secure.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -25,7 +25,7 @@ jobs:
   # case, to avoid confusion
   test-auto-requirements-txt-secure:
     needs: [ matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: main
     strategy:
       matrix:
@@ -47,7 +47,7 @@ jobs:
   # Same as above, but for a poetry lock file
   test-auto-poetry-secure:
     needs: [ matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: main
     strategy:
       matrix:
@@ -69,7 +69,7 @@ jobs:
   # Same as above, but for a Pipfile.lock
   test-auto-pipfile-secure:
     needs: [ matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: main
     strategy:
       matrix:
@@ -93,7 +93,7 @@ jobs:
   ### installs things in the root VM that the action runs on; this is what gets scanned.
   test-auto-environment-secure:
     needs: [ matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: main
     strategy:
       matrix:
@@ -121,7 +121,7 @@ jobs:
   ### Scans a recently built Docker container. This uses a few heuristics, defined in entrypoint.sh
   test-auto-docker-secure:
     needs: [ matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: main
     strategy:
       matrix:

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     setuptools>=19.3
     Click>=8.0.2
     requests
-    packaging>=21.0
+    packaging>=21.0,<22.0
     dparse>=0.6.2
     ruamel.yaml>=0.17.21
     dataclasses==0.8; python_version=="3.6"


### PR DESCRIPTION

- Packaging now is pinned to the maximum version compatible; this is `packaging>=21.0,<22.0`.
- Pinned the CI actions to the runner image with Python 3.6 support.