### PR TITLE
Dockerfile: Run on Python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 # Don't use WORKDIR here as per Github's docs
 RUN mkdir /app
@@ -6,7 +6,7 @@ RUN mkdir /app
 RUN apt-get update && apt-get -y install docker.io jq && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install poetry and pipenv; used for converting their respective lockfile formats to generic requirements.txt
-RUN cd /app && python3 -m pip install poetry==1.1.13 pipenv==2022.6.7
+RUN cd /app && python3 -m pip install poetry==1.3.0 pipenv==2022.12.19
 
 # Install this project dependencies
 COPY . /app


### PR DESCRIPTION
https://docs.python.org/3.11/whatsnew/3.11.html
> Python 3.11 is between 10-60% faster than Python 3.10. On average, we measured a 1.25x speedup on the standard benchmark suite.