### PR TITLE
Build docker image on image-builds push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "^(\\d+\\.\\d+(\\.\\d+)?)$"
+    branches: [image-builds]
 
 env:
     DOCKER_BUILDKIT: 1


### PR DESCRIPTION
We'll use the `image-builds` branch to push updates on the docker image.