### PR TITLE
transform_ignore - check for empty

### DIFF
--- a/safety/util.py
+++ b/safety/util.py
@@ -379,7 +379,7 @@ class DependentOption(click.Option):
 
 def transform_ignore(ctx, param, value):
     ignored_default_dict = {'reason': '', 'expires': None}
-    if isinstance(value, tuple):
+    if value and isinstance(value, tuple):
         # Following code is required to support the 2 ways of providing 'ignore'
         # --ignore=1234,567,789
         # or, the historical way (supported for backward compatibility)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -145,3 +145,6 @@ class ReadRequirementsTestCase(unittest.TestCase):
             '789': {'expires': None, 'reason': ''}
         }
         self.assertEqual(transform_ignore(None, None, value=("123,456", "789")), ignored_transformed)
+
+    def test_transform_empty(self):
+        self.assertEqual(transform_ignore(None, None, value=tuple()), {})


### PR DESCRIPTION
There appears to be a problem loading ignores from a policy file in 2.4.0b1 (and in `main`)
I believe it was introduced in #343

I added a new tests that trigger the issue (based on existing tests).

Let me know if you want me to adjust anything. (and no problem if you want do handle the fix yourself.)