### PR TITLE
Remove Unused Dependency: Urllib3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ install_requires =
     setuptools>=65.5.1; python_version>="3.7"
     setuptools; python_version=="3.6"
     Click>=8.0.2
-    urllib3>=1.26.5
     requests
     packaging>=21.0,<=23.0
     dparse>=0.6.2

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,7 +3,6 @@ pytest-cov
 setuptools>=65.5.1; python_version>="3.7"
 setuptools; python_version=="3.6"
 Click>=8.0.2
-urllib3>=1.26.5
 requests
 packaging>=21.0,<=23.0
 dparse>=0.6.2


### PR DESCRIPTION
## Summary

This pull request removes the unused dependency `urllib3` from the `setup.cfg` and the `test_requirements.txt` configuration files. The removal is a finding from ongoing research focused on identifying and eliminating code bloat within software projects.

## Rationale

The `urllib3` dependency was introduced in  509f977, but it appears to be unused within the source code. As this dependency is unnecessary, its removal will simplify the project's dependency management and reduce the project's overall footprint.

## Changes

- Removed the `urllib3` dependency from the `setup.cfg` file.

## Impact

- **Reduced Package Size**: The removal of this unused dependency will lead to a decrease in the overall size of the installed packages.
- **Simplified Dependency Tree**: Fewer dependencies make the project easier to maintain and can speed up installation.

This change aligns with the best practices in maintaining a clean and optimized codebase.
