### PR TITLE
Fixed that Python requirement gets into package metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ include_package_data = True
 packages = safety, safety.formatters,safety.formatters.schemas, safety.alerts
 package_dir =
     safety = safety
+python_requires = >=3.6
 install_requires =
     setuptools>=65.5.1; python_version>="3.7"
     setuptools; python_version=="3.6"
@@ -53,8 +54,6 @@ install_requires =
 [options.entry_points]
 console_scripts =
     safety = safety.cli:cli
-
-python_requires = >=3.6
 
 [options.extras_require]
 github = pygithub>=1.43.3


### PR DESCRIPTION
This addresses issue #464.

Details:

* The setup.cfg file already had a "python_requires" attribute, but it was in the "options.entry_points" section, from where it did not make its way into the package metadata. This fix moves the "python_requires" attribute into the "options" section. which should cause the package build process to add it to the package metadata.