### PR TITLE
perf: unpin authlib and remove jwt

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,8 +46,7 @@ install_requires =
     ruamel.yaml>=0.17.21
     jinja2>=3.1.0
     marshmallow>=3.15.0
-    Authlib==1.2.0
-    jwt==1.3.1
+    Authlib>=1.2.0
     rich
     typer
     pydantic>=1.10.12,<2.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -13,8 +13,7 @@ jinja2; python_version=="3.6"
 jinja2>=3.1.0; python_version>="3.7"
 marshmallow; python_version=="3.6"
 marshmallow>=3.15.0; python_version>="3.7"
-Authlib==1.2.0
-jwt==1.3.1
+Authlib>=1.2.0
 rich
 typer
 pydantic>=1.10.12,<2.0


### PR DESCRIPTION
We don't need `jwt`, and `authlib` should be unpinned.