### PR TITLE
fix: support pydantic2 by using safety_schemas 0.0.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,8 +49,8 @@ install_requires =
     Authlib>=1.2.0
     rich
     typer
-    pydantic>=1.10.12,<2.0
-    safety_schemas>=0.0.1
+    pydantic>=1.10.12
+    safety_schemas>=0.0.2
     typing-extensions>=4.7.1
 
 [options.entry_points]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -16,6 +16,6 @@ marshmallow>=3.15.0; python_version>="3.7"
 Authlib>=1.2.0
 rich
 typer
-pydantic>=1.10.12,<2.0
-safety_schemas>=0.0.1
+pydantic>=1.10.12
+safety_schemas>=0.0.2
 typing-extensions>=4.7.1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -285,11 +285,9 @@ class TestSafetyCLI(unittest.TestCase):
         path = os.path.join(dirname, "test_policy_file", "v3_0", filename)
         result = self.runner.invoke(cli.cli, ['validate', 'policy_file', '3.0', '--path', path])
         cleaned_stdout = click.unstyle(result.stderr)
-        msg_hint = 'report -> dependency-vulnerabilities -> transitive\n' \
-                   '  extra fields not permitted (type=value_error.extra)\n'
-        msg = f'Unable to load the Safety Policy file ("{path}"), this command only supports version 3.0, details: 1 validation error for Config\n{msg_hint}'
+        msg = f'Unable to load the Safety Policy file ("{path}"), this command only supports version 3.0, details: 1 validation error for Config'
 
-        self.assertEqual(msg, cleaned_stdout)
+        self.assertIn(msg, cleaned_stdout)
         self.assertEqual(result.exit_code, 1)
 
 

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -466,6 +466,7 @@ class TestSafety(unittest.TestCase):
     @patch("safety.util.get_used_options")
     @patch.object(click, 'get_current_context', Mock(command=Mock(name=Mock(return_value='check'))))
     def test_get_announcements_http_ok(self, get_used_options):
+        get_used_options.return_value = {}
 
         announcements = {
             "announcements": [{


### PR DESCRIPTION
Support for multiple Pydantic versions and upgrade safety_schemas version.