### PR TITLE
fix: hardcode typer version to 0.12.3 using version matching clause: typer==0.12.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     marshmallow>=3.15.0
     Authlib>=1.2.0
     rich
-    typer
+    typer==0.12.3
     pydantic>=1.10.12
     safety_schemas>=0.0.2
     typing-extensions>=4.7.1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -15,7 +15,7 @@ marshmallow; python_version=="3.6"
 marshmallow>=3.15.0; python_version>="3.7"
 Authlib>=1.2.0
 rich
-typer
+typer==0.12.3
 pydantic>=1.10.12
 safety_schemas>=0.0.2
 typing-extensions>=4.7.1


### PR DESCRIPTION
Safety CLI depends on _underscore methods defined in typer which are not guaranteed to be stable, even across bugfix version changes. Locking typer to the current version (0.12.3), while inconvenient, is unfortunately necessary to ensure that refactorings in typer do not negatively impact our users. Helps fix #511