### PR TITLE
fix: prevent downstream breakages by using compatible release version clauses (`~=` instead of `>=`)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,21 +37,21 @@ python_requires = >=3.7
 package_dir =
     safety = safety
 install_requires =
-    setuptools>=65.5.1
-    Click>=8.0.2
-    urllib3>=1.26.5
+    setuptools >= 65.5.1
+    Click >= 8.0.2
+    urllib3 >= 1.26.5
     requests
-    packaging>=21.0
-    dparse>=0.6.4b0
-    ruamel.yaml>=0.17.21
-    jinja2>=3.1.0
-    marshmallow>=3.15.0
-    Authlib>=1.2.0
+    packaging >= 21.0
+    dparse >= 0.6.4b0
+    ruamel.yaml >= 0.17.21
+    jinja2 >= 3.1.0
+    marshmallow >= 3.15.0
+    Authlib >= 1.2.0
     rich
-    typer==0.12.3
-    pydantic>=1.10.12
-    safety_schemas>=0.0.2
-    typing-extensions>=4.7.1
+    typer == 0.12.3
+    pydantic >= 1.10.12
+    safety_schemas >= 0.0.2
+    typing-extensions >= 4.7.1
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,21 +37,21 @@ python_requires = >=3.7
 package_dir =
     safety = safety
 install_requires =
-    setuptools >= 65.5.1
+    Authlib >= 1.2.0
     Click >= 8.0.2
-    urllib3 >= 1.26.5
-    requests
-    packaging >= 21.0
     dparse >= 0.6.4b0
-    ruamel.yaml >= 0.17.21
     jinja2 >= 3.1.0
     marshmallow >= 3.15.0
-    Authlib >= 1.2.0
-    rich
-    typer == 0.12.3
+    packaging >= 21.0
     pydantic >= 1.10.12
+    requests
+    rich
+    ruamel.yaml >= 0.17.21
     safety_schemas >= 0.0.2
+    setuptools >= 65.5.1
+    typer == 0.12.3
     typing-extensions >= 4.7.1
+    urllib3 >= 1.26.5
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,21 +37,21 @@ python_requires = >=3.7
 package_dir =
     safety = safety
 install_requires =
-    Authlib >= 1.2.0
-    Click >= 8.0.2
-    dparse >= 0.6.4b0
-    jinja2 >= 3.1.0
-    marshmallow >= 3.15.0
-    packaging >= 21.0
-    pydantic >= 1.10.12
-    requests
-    rich
-    ruamel.yaml >= 0.17.21
-    safety_schemas >= 0.0.2
-    setuptools >= 65.5.1
+    Authlib ~= 1.3
+    Click ~= 8.1
+    dparse ~= 0.6.4b0
+    jinja2 ~= 3.1
+    marshmallow ~= 3.21
+    packaging ~= 24.0
+    pydantic ~= 2.7
+    requests ~= 2.31
+    rich ~= 13.7
+    ruamel.yaml ~= 0.18.6
+    safety_schemas ~= 0.0.2
+    setuptools ~= 69.5
     typer == 0.12.3
-    typing-extensions >= 4.7.1
-    urllib3 >= 1.26.5
+    typing-extensions ~= 4.11
+    urllib3 ~= 2.2
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     marshmallow>=3.15.0
     Authlib>=1.2.0
     rich
-    typer
+    typer==0.12.3
     pydantic>=1.10.12
     safety_schemas>=0.0.2
     typing-extensions>=4.7.1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,21 +1,21 @@
-pytest == 7.4.4
-pytest-cov == 4.1.0
-setuptools >= 65.5.1; python_version >= "3.7"
-setuptools; python_version == "3.6"
+Authlib >= 1.2.0
 Click >= 8.0.2
-urllib3 >= 1.26.5
-requests
-packaging >= 21.0, <= 23.0
-dparse >= 0.6.2
-ruamel.yaml >= 0.17.21
 dataclasses == 0.8; python_version == "3.6"
+dparse >= 0.6.2
 jinja2; python_version == "3.6"
 jinja2 >= 3.1.0; python_version >= "3.7"
 marshmallow; python_version == "3.6"
 marshmallow >= 3.15.0; python_version >= "3.7"
-Authlib >= 1.2.0
-rich
-typer == 0.12.3
+packaging >= 21.0, <= 23.0
 pydantic >= 1.10.12
+pytest == 7.4.4
+pytest-cov == 4.1.0
+requests
+rich
+ruamel.yaml >= 0.17.21
 safety_schemas >= 0.0.2
+setuptools; python_version == "3.6"
+setuptools >= 65.5.1; python_version >= "3.7"
+typer == 0.12.3
 typing-extensions >= 4.7.1
+urllib3 >= 1.26.5

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,21 +1,21 @@
-Authlib >= 1.2.0
-Click >= 8.0.2
+Authlib ~= 1.3
+Click ~= 8.1
 dataclasses == 0.8; python_version == "3.6"
-dparse >= 0.6.2
+dparse ~= 0.6.4b0
 jinja2; python_version == "3.6"
-jinja2 >= 3.1.0; python_version >= "3.7"
+jinja2 ~= 3.1; python_version >= "3.7"
 marshmallow; python_version == "3.6"
-marshmallow >= 3.15.0; python_version >= "3.7"
-packaging >= 21.0, <= 23.0
-pydantic >= 1.10.12
+marshmallow ~= 3.21; python_version >= "3.7"
+packaging ~= 24.0
+pydantic ~= 2.7
 pytest == 7.4.4
 pytest-cov == 4.1.0
-requests
-rich
-ruamel.yaml >= 0.17.21
-safety_schemas >= 0.0.2
+requests ~= 2.31
+rich ~= 13.7
+ruamel.yaml ~= 0.18.6
+safety-schemas ~= 0.0.2
 setuptools; python_version == "3.6"
-setuptools >= 65.5.1; python_version >= "3.7"
+setuptools ~= 69.5; python_version >= "3.7"
 typer == 0.12.3
-typing-extensions >= 4.7.1
-urllib3 >= 1.26.5
+typing-extensions ~= 4.11
+urllib3 ~= 2.2

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -15,7 +15,7 @@ marshmallow; python_version=="3.6"
 marshmallow>=3.15.0; python_version>="3.7"
 Authlib>=1.2.0
 rich
-typer
+typer==0.12.3
 pydantic>=1.10.12
 safety_schemas>=0.0.2
 typing-extensions>=4.7.1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,21 +1,21 @@
-pytest==7.4.4
-pytest-cov==4.1.0
-setuptools>=65.5.1; python_version>="3.7"
-setuptools; python_version=="3.6"
-Click>=8.0.2
-urllib3>=1.26.5
+pytest == 7.4.4
+pytest-cov == 4.1.0
+setuptools >= 65.5.1; python_version >= "3.7"
+setuptools; python_version == "3.6"
+Click >= 8.0.2
+urllib3 >= 1.26.5
 requests
-packaging>=21.0,<=23.0
-dparse>=0.6.2
-ruamel.yaml>=0.17.21
-dataclasses==0.8; python_version=="3.6"
-jinja2; python_version=="3.6"
-jinja2>=3.1.0; python_version>="3.7"
-marshmallow; python_version=="3.6"
-marshmallow>=3.15.0; python_version>="3.7"
-Authlib>=1.2.0
+packaging >= 21.0, <= 23.0
+dparse >= 0.6.2
+ruamel.yaml >= 0.17.21
+dataclasses == 0.8; python_version == "3.6"
+jinja2; python_version == "3.6"
+jinja2 >= 3.1.0; python_version >= "3.7"
+marshmallow; python_version == "3.6"
+marshmallow >= 3.15.0; python_version >= "3.7"
+Authlib >= 1.2.0
 rich
-typer==0.12.3
-pydantic>=1.10.12
-safety_schemas>=0.0.2
-typing-extensions>=4.7.1
+typer == 0.12.3
+pydantic >= 1.10.12
+safety_schemas >= 0.0.2
+typing-extensions >= 4.7.1


### PR DESCRIPTION
Switching to ~= will prevent unintentionally breaking our users due to a major version change out of our control upstream. For packages still in beta (i.e. packages whose major versions equal zero), we use the latest "major.minor.bugfix" as the version identifier; otherwise we use "major.minor". Tested manually. I believe this PR fixes #511 in spirit.