### PR TITLE
fix: update pyinstaller target

### DIFF
--- a/safety.spec
+++ b/safety.spec
@@ -3,7 +3,7 @@
 block_cipher = None
 
 a = Analysis(
-    ['safety/cli.py'],
+    ['safety/__main__.py'],
     pathex=['.'],
     binaries=[],
     datas=[('safety/VERSION', './safety')],

--- a/safety/__main__.py
+++ b/safety/__main__.py
@@ -1,7 +1,5 @@
 """Allow safety to be executable through `python -m safety`."""
-from __future__ import absolute_import
-
-from .cli import cli
+from safety.cli import cli
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
Relative imports on `cli.py` are breaking the binaries; this changes the target scripts and fixes this issue.