### PR TITLE
fix: include all templates in the manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,7 @@ include README.md
 include README.old
 include safety/VERSION
 include safety/safety-policy-template.yml
-include safety/templates/index.html
+include safety/templates/*
 include safety/alerts/templates/*
 
 recursive-include tests *


### PR DESCRIPTION
Now, it includes all the files/dirs under the `templates` folder.