### PR TITLE
Increase request timeout to 30 seconds

### DIFF
--- a/safety/constants.py
+++ b/safety/constants.py
@@ -98,7 +98,7 @@ API_MIRRORS = [
     DATA_API_BASE_URL
 ]
 
-REQUEST_TIMEOUT = 5
+REQUEST_TIMEOUT = 30
 
 # Colors
 YELLOW = 'yellow'


### PR DESCRIPTION
As mentioned in #487, safety often times out for us. Increasing the timeout should fix it for us (and anyone else with slower internet connections, proxies etc).