### PR TITLE
Update URLs, Lint

### DIFF
--- a/safety/errors.py
+++ b/safety/errors.py
@@ -1,7 +1,16 @@
 from typing import Optional
-from safety.constants import EXIT_CODE_EMAIL_NOT_VERIFIED, EXIT_CODE_FAILURE, EXIT_CODE_INVALID_API_KEY, EXIT_CODE_TOO_MANY_REQUESTS, \
-    EXIT_CODE_UNABLE_TO_FETCH_VULNERABILITY_DB, EXIT_CODE_UNABLE_TO_LOAD_LOCAL_VULNERABILITY_DB, EXIT_CODE_MALFORMED_DB, \
-    EXIT_CODE_INVALID_PROVIDED_REPORT, EXIT_CODE_INVALID_REQUIREMENT
+
+from safety.constants import (
+    EXIT_CODE_EMAIL_NOT_VERIFIED,
+    EXIT_CODE_FAILURE,
+    EXIT_CODE_INVALID_API_KEY,
+    EXIT_CODE_INVALID_PROVIDED_REPORT,
+    EXIT_CODE_INVALID_REQUIREMENT,
+    EXIT_CODE_MALFORMED_DB,
+    EXIT_CODE_TOO_MANY_REQUESTS,
+    EXIT_CODE_UNABLE_TO_FETCH_VULNERABILITY_DB,
+    EXIT_CODE_UNABLE_TO_LOAD_LOCAL_VULNERABILITY_DB,
+)
 
 
 class SafetyException(Exception):
@@ -83,7 +92,7 @@ class InvalidCredentialError(DatabaseFetchError):
 
     def __init__(self, credential: Optional[str] = None, message="Your authentication credential{credential}is invalid. See {link}.", reason=None):
         self.credential = credential
-        self.link = 'https://bit.ly/3OY2wEI'
+        self.link = 'https://docs.safetycli.com/safety-docs/support/invalid-api-key-error'
         self.message = message.format(credential=f" '{self.credential}' ", link=self.link) if self.credential else message.format(credential=' ', link=self.link)
         info = f" Reason: {reason}"
         self.message = self.message + (info if reason else "")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,19 +1,19 @@
 import json
 import os
-from pathlib import Path
 import shutil
 import tempfile
 import unittest
 from datetime import datetime
-from packaging.version import Version
-from packaging.specifiers import SpecifierSet
-from unittest.mock import patch, Mock
+from pathlib import Path
+from unittest.mock import Mock, patch
 
 import click
 from click.testing import CliRunner
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 
 from safety import cli
-from safety.models import Vulnerability, CVE, Severity, SafetyRequirement
+from safety.models import CVE, SafetyRequirement, Severity, Vulnerability
 from safety.util import Package, SafetyContext
 
 
@@ -70,7 +70,7 @@ class TestSafetyCLI(unittest.TestCase):
         self.output_options = ['screen', 'text', 'json', 'bare']
         self.dirname = os.path.dirname(__file__)
 
-    def test_command_line_interface(self):        
+    def test_command_line_interface(self):
         runner = CliRunner()
         result = runner.invoke(cli.cli)
         expected = "Usage: cli [OPTIONS] COMMAND [ARGS]..."
@@ -234,7 +234,7 @@ class TestSafetyCLI(unittest.TestCase):
                         "cvss_severity": [
                             "critical",
                             "high",
-                            "medium",                    
+                            "medium",
                         ],
                         "exploitability": [
                             "critical",
@@ -330,7 +330,7 @@ class TestSafetyCLI(unittest.TestCase):
         req_file = os.path.join(dirname, "test_fix", "basic", "reqs_simple.txt")
         result = self.runner.invoke(cli.cli, ['check', '-r', req_file, '--apply-security-updates'])
         self.assertEqual(click.unstyle(result.stderr),
-                         "The --apply-security-updates option needs authentication. See https://bit.ly/3OY2wEI.\n")
+                         "The --apply-security-updates option needs authentication. See https://docs.safetycli.com/safety-docs/support/invalid-api-key-error.\n")
         self.assertEqual(result.exit_code, 65)
 
     def test_check_with_fix_only_works_with_files(self):

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -19,19 +19,35 @@ from json import JSONDecodeError
 from unittest.mock import Mock, patch
 
 import click as click
-from packaging.version import parse
 from packaging.specifiers import SpecifierSet
+from packaging.version import parse
 from requests.exceptions import RequestException
+
 from safety.auth import build_client_session
 from safety.constants import DB_CACHE_FILE
-
-from safety.errors import DatabaseFetchError, DatabaseFileNotFoundError, MalformedDatabase, InvalidCredentialError, TooManyRequestsError
+from safety.errors import (
+    DatabaseFetchError,
+    DatabaseFileNotFoundError,
+    InvalidCredentialError,
+    MalformedDatabase,
+    TooManyRequestsError,
+)
 from safety.formatter import SafetyFormatter
 from safety.models import CVE, Package, SafetyRequirement
-from safety.safety import get_announcements, ignore_vuln_if_needed, get_closest_ver, precompute_remediations, compute_sec_ver, \
-    calculate_remediations, read_vulnerabilities, check, get_licenses, review
+from safety.safety import (
+    calculate_remediations,
+    check,
+    compute_sec_ver,
+    get_announcements,
+    get_closest_ver,
+    get_licenses,
+    ignore_vuln_if_needed,
+    precompute_remediations,
+    read_vulnerabilities,
+    review,
+)
 from safety.util import get_packages_licenses, read_requirements
-from tests.resources import VALID_REPORT, VULNS, SCANNED_PACKAGES, REMEDIATIONS
+from tests.resources import REMEDIATIONS, SCANNED_PACKAGES, VALID_REPORT, VULNS
 from tests.test_cli import get_vulnerability
 
 
@@ -140,7 +156,7 @@ class TestSafety(unittest.TestCase):
         packages = read_requirements(reqs)
 
         vulns, _ = check(
-            session=self.session,            
+            session=self.session,
             packages=packages,
             db_mirror=False,
             cached=0,
@@ -237,7 +253,7 @@ class TestSafety(unittest.TestCase):
                 telemetry=False
             )
         db_generic_exception = error.exception
-        self.assertEqual(str(db_generic_exception), 'Your authentication credential is invalid. See https://bit.ly/3OY2wEI.')
+        self.assertEqual(str(db_generic_exception), 'Your authentication credential is invalid. See https://docs.safetycli.com/safety-docs/support/invalid-api-key-error.')
 
 
     def test_get_packages_licenses_with_invalid_api_key(self):
@@ -459,7 +475,7 @@ class TestSafety(unittest.TestCase):
             api_key = "somekey"
             session.api_key = api_key
             session.headers = {'X-Api-Key': api_key}
-            session.get.return_value = mock          
+            session.get.return_value = mock
 
             self.assertEqual(get_announcements(session), [])
 
@@ -511,7 +527,7 @@ class TestSafety(unittest.TestCase):
         api_key = "somekey"
         session.api_key = api_key
         session.headers = {'X-Api-Key': api_key}
-        session.get.return_value = mock        
+        session.get.return_value = mock
 
         self.assertEqual(get_announcements(session), [])
 
@@ -524,7 +540,7 @@ class TestSafety(unittest.TestCase):
         api_key = "somekey"
         session.api_key = api_key
         session.headers = {'X-Api-Key': api_key}
-        session.get.return_value = mock        
+        session.get.return_value = mock
 
         self.assertEqual(get_announcements(session), [])
 


### PR DESCRIPTION
https://linear.app/pyup/issue/SFTY-657/update-invalid-api-key-url

This PR changes updates all references of the URL https://bit.ly/3OY2wEI to:
https://docs.safetycli.com/safety-docs/support/invalid-api-key-error