### PR TITLE
feat: add GitHub Action to automatically respond to new issues

### DIFF
--- a/.github/workflows/issue_responder.yml
+++ b/.github/workflows/issue_responder.yml
@@ -22,6 +22,8 @@ jobs:
           We appreciate your effort in reporting this. Our team will review it and get back to you soon.
           If you have any additional details or updates, feel free to add them to this issue.
 
+          **Note:** If this is a serious security issue that could impact the security of Safety CLI users, please email security@safetycli.com immediately.
+
           Thank you for contributing to Safety CLI!
           `;
 

--- a/.github/workflows/issue_responder.yml
+++ b/.github/workflows/issue_responder.yml
@@ -15,9 +15,8 @@ jobs:
         script: |
           const issueNumber = context.issue.number;
           const issueTitle = context.payload.issue.title;
-          const issueBody = context.payload.issue.body;
 
-          const commentBody = `Thank you for opening this issue!\n\nTitle: ${issueTitle}\n\nBody: ${issueBody}\n\nWe will look into it and get back to you soon.`;
+          const commentBody = `Thank you for opening this issue!\n\nWe will look into it and get back to you soon.`;
 
           github.issues.createComment({
             ...context.repo,

--- a/.github/workflows/issue_responder.yml
+++ b/.github/workflows/issue_responder.yml
@@ -14,11 +14,18 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const issueNumber = context.issue.number;
-          const issueTitle = context.payload.issue.title;
+          const issueAuthor = context.payload.issue.user.login;
 
-          const commentBody = `Thank you for opening this issue!\n\nWe will look into it and get back to you soon.`;
+          const commentBody = `
+          Hi @${issueAuthor}, thank you for opening this issue!
 
-          github.issues.createComment({
+          We appreciate your effort in reporting this. Our team will review it and get back to you soon.
+          If you have any additional details or updates, feel free to add them to this issue.
+
+          Thank you for contributing to Safety CLI!
+          `;
+
+          await github.issues.createComment({
             ...context.repo,
             issue_number: issueNumber,
             body: commentBody

--- a/.github/workflows/issue_responder.yml
+++ b/.github/workflows/issue_responder.yml
@@ -1,0 +1,26 @@
+name: Issue Responder
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  respond:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Respond to new issues
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const issueNumber = context.issue.number;
+          const issueTitle = context.payload.issue.title;
+          const issueBody = context.payload.issue.body;
+
+          const commentBody = `Thank you for opening this issue!\n\nTitle: ${issueTitle}\n\nBody: ${issueBody}\n\nWe will look into it and get back to you soon.`;
+
+          github.issues.createComment({
+            ...context.repo,
+            issue_number: issueNumber,
+            body: commentBody
+          });


### PR DESCRIPTION
**Description**
This pull request adds a new GitHub Action that automatically responds to new issues created in the repository. The action is configured to trigger whenever a new issue is opened and posts a predefined comment thanking the user and acknowledging the issue.

**Changes**
- Added a new GitHub Action workflow file .github/workflows/issue-responder.yml.
- Configured the workflow to trigger on the issues event with the type opened.
- The action uses actions/github-script@v7 to post a comment on the newly created issue.
- The comment includes the title and body of the issue and a thank-you message.
- The comment will appear as if posted by the account associated with the GITHUB_TOKEN.
- This setup ensures a single response per new issue.