### PR TITLE
Fix Issue Responder Workflow to Correctly Add Comments

### DIFF
--- a/.github/workflows/issue_responder.yml
+++ b/.github/workflows/issue_responder.yml
@@ -7,28 +7,25 @@ on:
 jobs:
   respond:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
-    - name: Respond to new issues
-      uses: actions/github-script@v7
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const issueNumber = context.issue.number;
-          const issueAuthor = context.payload.issue.user.login;
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-          const commentBody = `
-          Hi @${issueAuthor}, thank you for opening this issue!
+      - name: Install GitHub CLI
+        run: sudo apt-get install gh
 
-          We appreciate your effort in reporting this. Our team will review it and get back to you soon.
-          If you have any additional details or updates, feel free to add them to this issue.
+      - name: Respond to new issues
+        run: gh issue comment ${{ github.event.issue.number }} --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY: |
+            Hi @${{ github.event.issue.user.login }}, thank you for opening this issue!
 
-          **Note:** If this is a serious security issue that could impact the security of Safety CLI users, please email security@safetycli.com immediately.
+            We appreciate your effort in reporting this. Our team will review it and get back to you soon.
+            If you have any additional details or updates, feel free to add them to this issue.
 
-          Thank you for contributing to Safety CLI!
-          `;
+            **Note:** If this is a serious security issue that could impact the security of Safety CLI users, please email security@safetycli.com immediately.
 
-          await github.issues.createComment({
-            ...context.repo,
-            issue_number: issueNumber,
-            body: commentBody
-          });
+            Thank you for contributing to Safety CLI!


### PR DESCRIPTION
**Description:**
This PR addresses an issue with the issue_responder.yml workflow where new issues were not being responded to automatically due to a TypeError related to the createComment method. The issue was caused by using the outdated github.issues.createComment method instead of the github.rest.issues.createComment method. In this PR, we provide an alternative approach using the gh CLI for simplicity and ease of maintenance.

**Changes Made:**
Added Alternative Approach Using gh CLI:
- Provided an alternative implementation using the gh CLI for adding comments to new issues.
- This method simplifies the workflow and avoids potential issues with the github-script action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined the issue response process by utilizing the GitHub CLI for commenting on new issues.
	- Improved performance and reliability of issue handling.

- **Chores**
	- Enhanced clarity on permissions for writing to issues within the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->