### PR TITLE
Add Table of Contents to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Safety is released under the MIT License.
 
 Upon creating an account, a 7-day free trial of our Team plan is offered to new users, after which they will be downgraded to our Free plan. This plan is limited to a single user and is not recommended for commercial purposes.
 
-Our paid [plans for commercial use](https://safetycli.com/resources/plans) begin at just $25 per seat per month and allow scans to be performed using our full vulnerability database, complete with 3x more tracked vulnerabilities and malicious packages than our free plan and other providers. To learn more about our Team and Enterprise plans, [https://safetycli.com/resources/plans](https://safetycli.com/resources/plans) or email sales@safetycli.com.
+Our paid [plans for commercial use](https://safetycli.com/resources/plans) begin at just $25 per seat per month and allow scans to be performed using our full vulnerability database, complete with 3x more tracked vulnerabilities and malicious packages than our free plan and other providers. To learn more about our Team and Enterprise plans, please visit [https://safetycli.com/resources/plans](https://safetycli.com/resources/plans) or email sales@safetycli.com.
 
 # Supported Python Versions
 Safety CLI 3 supports Python versions >=3.7. Further details on supported versions, as well as options to run Safety CLI on versions <3.7 using a Docker image are available in our [Documentation Hub](https://docs.safetycli.com).

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Leveraging the industry's most comprehensive database of vulnerabilities and mal
 
 
 # Detailed Documentation
-Full documentation is available at https://docs.safetycli.com.
+Full documentation is available at [https://docs.safetycli.com](https://docs.safetycli.com).
 
 Included in the documentation are the following key topics:
 
@@ -120,7 +120,7 @@ Included in the documentation are the following key topics:
 - [Safety 2.x Documentation](https://docs.safetycli.com/safety-2)
 - [Support](https://docs.safetycli.com/safety-docs/miscellaneous/support)
 
-System status is available at https://status.safetycli.com
+System status is available at [https://status.safetycli.com](https://status.safetycli.com)
 
 Further support is available by emailing support@safetycli.com.
 
@@ -129,7 +129,7 @@ Safety is released under the MIT License.
 
 Upon creating an account, a 7-day free trial of our Team plan is offered to new users, after which they will be downgraded to our Free plan. This plan is limited to a single user and is not recommended for commercial purposes.
 
-Our paid [plans for commercial use](https://safetycli.com/resources/plans) begin at just $25 per seat per month and allow scans to be performed using our full vulnerability database, complete with 3x more tracked vulnerabilities and malicious packages than our free plan and other providers. To learn more about our Team and Enterprise plans, please visit https://safetycli.com/resources/plans or email sales@safetycli.com.
+Our paid [plans for commercial use](https://safetycli.com/resources/plans) begin at just $25 per seat per month and allow scans to be performed using our full vulnerability database, complete with 3x more tracked vulnerabilities and malicious packages than our free plan and other providers. To learn more about our Team and Enterprise plans, [https://safetycli.com/resources/plans](https://safetycli.com/resources/plans) or email sales@safetycli.com.
 
 # Supported Python Versions
 Safety CLI 3 supports Python versions >=3.7. Further details on supported versions, as well as options to run Safety CLI on versions <3.7 using a Docker image are available in our [Documentation Hub](https://docs.safetycli.com).

--- a/README.md
+++ b/README.md
@@ -10,8 +10,24 @@
 > [!NOTE]
 > [Come and join us at SafetyCLI](https://apply.workable.com/safety/). We are hiring for various roles.
 
+# Table of Contents
+- [Table of Contents](#table-of-contents)
+- [Introduction](#introduction)
+- [Key Features](#key-features)
+- [Getting Started](#getting-started)
+  - [GitHub Action](#github-action)
+  - [Command Line Interface](#command-line-interface)
+    - [1. Installation](#1-installation)
+    - [2. Log In or Register](#2-log-in-or-register)
+    - [3. Running Your First Scan](#3-running-your-first-scan)
+  - [Basic Commands](#basic-commands)
+- [Detailed Documentation](#detailed-documentation)
+- [License](#license)
+- [Supported Python Versions](#supported-python-versions)
+- [Resources](#resources)
+
 # Introduction
-Safety CLI is a Python dependency vulnerability scanner designed to enhance software supply chain security by detecting packages with known vulnerabilities and malicious packages in local development environments, CI/CD, and production systems. 
+Safety CLI is a Python dependency vulnerability scanner designed to enhance software supply chain security by detecting packages with known vulnerabilities and malicious packages in local development environments, CI/CD, and production systems.
 Safety CLI can be deployed in minutes and provides clear, actionable recommendations for remediation of detected vulnerabilities.
 
 Leveraging the industry's most comprehensive database of vulnerabilities and malicious packages, Safety CLI Scanner allows teams to detect vulnerabilities at every stage of the software development lifecycle.
@@ -60,7 +76,7 @@ Leveraging the industry's most comprehensive database of vulnerabilities and mal
 
 
 # Detailed Documentation
-Full documentation is available at https://docs.safetycli.com. 
+Full documentation is available at https://docs.safetycli.com.
 
 Included in the documentation are the following key topics:
 
@@ -106,17 +122,17 @@ Included in the documentation are the following key topics:
 
 System status is available at https://status.safetycli.com
 
-Further support is available by emailing support@safetycli.com. 
+Further support is available by emailing support@safetycli.com.
 
 # License
-Safety is released under the MIT License. 
+Safety is released under the MIT License.
 
 Upon creating an account, a 7-day free trial of our Team plan is offered to new users, after which they will be downgraded to our Free plan. This plan is limited to a single user and is not recommended for commercial purposes.
 
-Our paid [plans for commercial use](https://safetycli.com/resources/plans) begin at just $25 per seat per month and allow scans to be performed using our full vulnerability database, complete with 3x more tracked vulnerabilities and malicious packages than our free plan and other providers. To learn more about our Team and Enterprise plans, please visit https://safetycli.com/resources/plans or email sales@safetycli.com. 
+Our paid [plans for commercial use](https://safetycli.com/resources/plans) begin at just $25 per seat per month and allow scans to be performed using our full vulnerability database, complete with 3x more tracked vulnerabilities and malicious packages than our free plan and other providers. To learn more about our Team and Enterprise plans, please visit https://safetycli.com/resources/plans or email sales@safetycli.com.
 
 # Supported Python Versions
-Safety CLI 3 supports Python versions >=3.7. Further details on supported versions, as well as options to run Safety CLI on versions <3.7 using a Docker image are available in our [Documentation Hub](https://docs.safetycli.com). 
+Safety CLI 3 supports Python versions >=3.7. Further details on supported versions, as well as options to run Safety CLI on versions <3.7 using a Docker image are available in our [Documentation Hub](https://docs.safetycli.com).
 
 We maintain a policy of supporting all maintained and secure versions of Python, plus one minor version below the oldest maintained and secure version. Details on Python versions that meet these criteria can be found here: https://endoflife.date/python.
 


### PR DESCRIPTION
**Summary**
This pull request adds a Table of Contents (TOC) section to the README.md file for the Safety CLI project. The TOC improves the readability and navigation of the documentation by providing quick links to various sections within the README.

**Changes**
* Added a "Table of Contents" section after the badges.
* Updated the README.md file to include links to:
    * Introduction
    * Key Features
    * Getting Started
        * GitHub Action
        * Command Line Interface
            * Installation
            * Log In or Register
            * Running Your First Scan
        * Basic Commands
    * Detailed Documentation
        * Safety CLI 3
        * Vulnerability Remediation
        * Integration
        * Administration
        * Output
        * Miscellaneous
    * License
    * Supported Python Versions
    * Resources

**Motivation**
The addition of a TOC helps users to easily navigate through the comprehensive information provided in the README. It enhances user experience by making it simpler to find relevant sections quickly.
Checklist
* Added a Table of Contents section to README.md.
* Verified the links to each section within the README.md.
* Ensured that the structure and headings of the README.md remain consistent and clear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Introduced a structured "Table of Contents" in the README for improved navigation.
	- Enhanced organization of the "Getting Started" section with clearly defined subsections.
	- Made minor formatting adjustments for better readability and consistency.
	- Added hyperlinks for better accessibility within the document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->