### PR TITLE
chore/update-coc-email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,7 +46,7 @@ If you are experiencing or witnessing conflict, we ask you to use the following 
 3. If you are still unable to resolve the conflict, and you believe it rises to harassment or another code of conduct violation, report it.
 
 ## Reporting Violations
-Violations of the Code of Conduct can be reported to Safety CLI’s Project Stewards, [Name] ([email]), and [Name] ([email]). The Project Steward will determine whether the Code of Conduct was violated, and will issue an appropriate sanction, possibly including a written warning or expulsion from the project, project sponsored spaces, or project forums. We ask that you make a good-faith effort to resolve your conflict via the conflict resolution policy before submitting a report.
+Violations of the Code of Conduct can be reported to [engineers@safetycli.com](mailto:engineers@safetycli.com). The Project Steward will determine whether the Code of Conduct was violated, and will issue an appropriate sanction, possibly including a written warning or expulsion from the project, project sponsored spaces, or project forums. We ask that you make a good-faith effort to resolve your conflict via the conflict resolution policy before submitting a report.
 
 Violations of the Code of Conduct can occur in any setting, even those unrelated to the project. We will only consider complaints about conduct that has occurred within one year of the report.
 


### PR DESCRIPTION
Update to use [engineers@safetycli.com](mailto:engineers@safetycli.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Code of Conduct to simplify the reporting process by consolidating contact information to a single email address for reporting violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->