### PR TITLE
Automate Addition of First-Time Contributors to SendGrid List

### DIFF
--- a/.github/workflows/send-thank-you-email.yml
+++ b/.github/workflows/send-thank-you-email.yml
@@ -30,9 +30,9 @@ jobs:
           body: |
             Hi ${{ github.actor }},
 
-            Thank you for your first contribution to our project! We truly appreciate your effort and look forward to more of your contributions.
+            Thank you for your first contribution to the Safety CLI project! We truly appreciate your effort and look forward to more of your contributions.
 
             Best Regards,
-            The Team
+            The Safety CLI Team
           to: ${{ github.actor }}@users.noreply.github.com
           from: your_email@example.com

--- a/.github/workflows/send-thank-you-email.yml
+++ b/.github/workflows/send-thank-you-email.yml
@@ -1,0 +1,38 @@
+name: Send Thank You Email
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  send-email:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Count Merged PRs
+        id: count_prs
+        run: |
+          PR_COUNT=$(gh pr list --author ${{ github.actor }} --state merged --repo ${{ github.repository }} --json number --jq '. | length')
+          echo "PR_COUNT=$PR_COUNT" >> $GITHUB_ENV
+
+      - name: Send Thank You Email
+        if: ${{ env.PR_COUNT }} == 1
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.example.com
+          server_port: 587
+          username: ${{ secrets.SMTP_USERNAME }}
+          password: ${{ secrets.SMTP_PASSWORD }}
+          subject: "Thank You for Your First PR!"
+          body: |
+            Hi ${{ github.actor }},
+
+            Thank you for your first contribution to our project! We truly appreciate your effort and look forward to more of your contributions.
+
+            Best Regards,
+            The Team
+          to: ${{ github.actor }}@users.noreply.github.com
+          from: your_email@example.com

--- a/.github/workflows/send-thank-you-email.yml
+++ b/.github/workflows/send-thank-you-email.yml
@@ -1,11 +1,11 @@
-name: Send Thank You Email
+name: Add User to SendGrid List on First PR Merge
 
 on:
   pull_request:
     types: [closed]
 
 jobs:
-  send-email:
+  add-to-sendgrid-list:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     steps:
@@ -18,21 +18,11 @@ jobs:
           PR_COUNT=$(gh pr list --author ${{ github.actor }} --state merged --repo ${{ github.repository }} --json number --jq '. | length')
           echo "PR_COUNT=$PR_COUNT" >> $GITHUB_ENV
 
-      - name: Send Thank You Email
+      - name: Add User to SendGrid List
         if: ${{ env.PR_COUNT }} == 1
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.example.com
-          server_port: 587
-          username: ${{ secrets.SMTP_USERNAME }}
-          password: ${{ secrets.SMTP_PASSWORD }}
-          subject: "Thank You for Your First PR!"
-          body: |
-            Hi ${{ github.actor }},
-
-            Thank you for your first contribution to the Safety CLI project! We truly appreciate your effort and look forward to more of your contributions.
-
-            Best Regards,
-            The Safety CLI Team
-          to: ${{ github.actor }}@users.noreply.github.com
-          from: your_email@example.com
+        run: |
+          curl --request POST \
+            --url https://api.sendgrid.com/v3/marketing/contacts \
+            --header "Authorization: Bearer ${{ secrets.SENDGRID_API_KEY }}" \
+            --header 'Content-Type: application/json' \
+            --data '{"list_ids":["OUR_LIST_ID"],"contacts":[{"email":"${{ github.actor }}@users.noreply.github.com"}]}'


### PR DESCRIPTION
This PR introduces an automation that adds contributors to a SendGrid email list upon merging their first PR. The key changes include:
- **Action Workflow:**
    * Created a GitHub Action that triggers on PR merge events.
    * Counts the number of PRs merged by the contributor to determine if it’s their first contribution.
- **SendGrid Integration:**
    * If the PR is the contributor's first merge, their GitHub email (`${{ github.actor }}@users.noreply.github.com`) is automatically added to a designated SendGrid list using the SendGrid API.
- **Rationale:**
    * This automation aims to recognize and welcome new contributors to the project by enrolling them in an email list, where they can receive a thank-you email and potentially other communications.
- **Configuration:**
    * SendGrid API key is stored securely in GitHub Secrets as `SENDGRID_API_KEY`.
    * Contributors are added to a specific list in SendGrid identified by `OUR_LIST_ID`.
- **Next Steps:**
    * Verify that the integration with SendGrid works as expected by testing with a test contributor.
    * Collaborate with the marketing team to finalize the email content and further automation within SendGrid.