### PR TITLE
chore/hide-system-scan-from-help-text

### DIFF
--- a/safety/scan/command.py
+++ b/safety/scan/command.py
@@ -510,6 +510,7 @@ def scan(ctx: typer.Context,
 @scan_system_app.command(
         cls=SafetyCLICommand,
         help=CLI_SYSTEM_SCAN_COMMAND_HELP,
+        hidden=True,
         options_metavar="[COMMAND-OPTIONS]",
         name=CMD_SYSTEM_NAME, epilog=DEFAULT_EPILOG)
 @handle_cmd_exception


### PR DESCRIPTION
This PR hides the system-scan text from the CLI help text: 
<img width="683" alt="image" src="https://github.com/user-attachments/assets/e6c48a55-d1ff-43bb-b31a-3f00c3b3dfa3">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a hidden command in the command-line interface for sorting vulnerabilities by score, enhancing command organization without altering functionality.
  
- **Bug Fixes**
	- No bug fixes were included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->