### PR TITLE
Add Script to Generate CONTRIBUTORS.md with Shields.io Badges Based on Merged PRs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,19 @@
+# Contributors
+
+## Valued Contributor
+
+- ![yeisonvargasf Badge](https://img.shields.io/badge/yeisonvargasf-Valued%20Contributor-brightgreen) (46 merged PRs)
+
+- ![dylanpulver Badge](https://img.shields.io/badge/dylanpulver-Valued%20Contributor-brightgreen) (29 merged PRs)
+
+## First Contributor
+
+- ![cclauss Badge](https://img.shields.io/badge/cclauss-First%20Contributor-brightgreen) (2 merged PRs)
+
+- ![cb22 Badge](https://img.shields.io/badge/cb22-First%20Contributor-brightgreen) (2 merged PRs)
+
+- ![Zeckie Badge](https://img.shields.io/badge/Zeckie-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![mwermuth Badge](https://img.shields.io/badge/mwermuth-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![Jwomers Badge](https://img.shields.io/badge/Jwomers-First%20Contributor-brightgreen) (1 merged PRs)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,18 +2,82 @@
 
 ## Valued Contributor
 
-- ![yeisonvargasf Badge](https://img.shields.io/badge/yeisonvargasf-Valued%20Contributor-brightgreen) (46 merged PRs)
+- ![yeisonvargasf Badge](https://img.shields.io/badge/yeisonvargasf-Valued%20Contributor-brightgreen) (66 merged PRs)
 
 - ![dylanpulver Badge](https://img.shields.io/badge/dylanpulver-Valued%20Contributor-brightgreen) (29 merged PRs)
 
+- ![pyup-bot Badge](https://img.shields.io/badge/pyup--bot-Valued%20Contributor-brightgreen) (23 merged PRs)
+
+## Frequent Contributor
+
+- ![nicholasks Badge](https://img.shields.io/badge/nicholasks-Frequent%20Contributor-brightgreen) (7 merged PRs)
+
+- ![cb22 Badge](https://img.shields.io/badge/cb22-Frequent%20Contributor-brightgreen) (6 merged PRs)
+
 ## First Contributor
+
+- ![Jwomers Badge](https://img.shields.io/badge/Jwomers-First%20Contributor-brightgreen) (4 merged PRs)
+
+- ![PeterDaveHello Badge](https://img.shields.io/badge/PeterDaveHello-First%20Contributor-brightgreen) (3 merged PRs)
+
+- ![rafaelpivato Badge](https://img.shields.io/badge/rafaelpivato-First%20Contributor-brightgreen) (3 merged PRs)
 
 - ![cclauss Badge](https://img.shields.io/badge/cclauss-First%20Contributor-brightgreen) (2 merged PRs)
 
-- ![cb22 Badge](https://img.shields.io/badge/cb22-First%20Contributor-brightgreen) (2 merged PRs)
+- ![chowmean Badge](https://img.shields.io/badge/chowmean-First%20Contributor-brightgreen) (2 merged PRs)
+
+- ![engnadeau Badge](https://img.shields.io/badge/engnadeau-First%20Contributor-brightgreen) (2 merged PRs)
 
 - ![Zeckie Badge](https://img.shields.io/badge/Zeckie-First%20Contributor-brightgreen) (1 merged PRs)
 
 - ![mwermuth Badge](https://img.shields.io/badge/mwermuth-First%20Contributor-brightgreen) (1 merged PRs)
 
-- ![Jwomers Badge](https://img.shields.io/badge/Jwomers-First%20Contributor-brightgreen) (1 merged PRs)
+- ![tarmack Badge](https://img.shields.io/badge/tarmack-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![andyjones Badge](https://img.shields.io/badge/andyjones-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![bagerard Badge](https://img.shields.io/badge/bagerard-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![jorgecarleitao Badge](https://img.shields.io/badge/jorgecarleitao-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![GhostofGoes Badge](https://img.shields.io/badge/GhostofGoes-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![sobolevn Badge](https://img.shields.io/badge/sobolevn-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![eschluntz Badge](https://img.shields.io/badge/eschluntz-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![redshiftzero Badge](https://img.shields.io/badge/redshiftzero-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![dhrmn Badge](https://img.shields.io/badge/dhrmn-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![msmolens Badge](https://img.shields.io/badge/msmolens-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![a-recknagel Badge](https://img.shields.io/badge/a--recknagel-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![4383 Badge](https://img.shields.io/badge/4383-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![hmajid2301 Badge](https://img.shields.io/badge/hmajid2301-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![mgedmin Badge](https://img.shields.io/badge/mgedmin-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![ayeks Badge](https://img.shields.io/badge/ayeks-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![benjaminp Badge](https://img.shields.io/badge/benjaminp-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![duncm Badge](https://img.shields.io/badge/duncm-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![svenevs Badge](https://img.shields.io/badge/svenevs-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![filipochnik Badge](https://img.shields.io/badge/filipochnik-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![thatarchguy Badge](https://img.shields.io/badge/thatarchguy-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![AndreLouisCaron Badge](https://img.shields.io/badge/AndreLouisCaron-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![klada Badge](https://img.shields.io/badge/klada-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![Stype Badge](https://img.shields.io/badge/Stype-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![maratsh Badge](https://img.shields.io/badge/maratsh-First%20Contributor-brightgreen) (1 merged PRs)
+
+- ![dveeden Badge](https://img.shields.io/badge/dveeden-First%20Contributor-brightgreen) (1 merged PRs)

--- a/scripts/generate_contributors.py
+++ b/scripts/generate_contributors.py
@@ -13,11 +13,23 @@ TIERS = {"Valued Contributor": 10, "Frequent Contributor": 5, "First Contributor
 
 # API request to get merged PRs
 def get_merged_prs():
-    url = f"https://api.github.com/repos/{GITHUB_REPO}/pulls?state=closed&per_page=100"
-    headers = {"Authorization": f"token {GITHUB_TOKEN}"}
-    response = requests.get(url, headers=headers)
-    response.raise_for_status()
-    return response.json()
+    prs = []
+    page = 1
+    while True:
+        url = f"https://api.github.com/repos/{GITHUB_REPO}/pulls?state=closed&per_page=100&page={page}"
+        headers = {"Authorization": f"token {GITHUB_TOKEN}"}
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        page_prs = response.json()
+
+        # Break if there are no more PRs
+        if not page_prs:
+            break
+
+        prs.extend(page_prs)
+        page += 1
+
+    return prs
 
 
 # Count contributions for each user

--- a/scripts/generate_contributors.py
+++ b/scripts/generate_contributors.py
@@ -1,0 +1,78 @@
+import os
+import requests
+from collections import defaultdict
+
+# Repository details and GitHub token
+GITHUB_REPO = "pyupio/safety"
+GITHUB_TOKEN = os.getenv("YOUR_GITHUB_TOKEN")
+CONTRIBUTORS_FILE = "CONTRIBUTORS.md"
+
+# Tier thresholds
+TIERS = {"Valued Contributor": 10, "Frequent Contributor": 5, "First Contributor": 1}
+
+
+# API request to get merged PRs
+def get_merged_prs():
+    url = f"https://api.github.com/repos/{GITHUB_REPO}/pulls?state=closed&per_page=100"
+    headers = {"Authorization": f"token {GITHUB_TOKEN}"}
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    return response.json()
+
+
+# Count contributions for each user
+def count_contributions(prs):
+    contributions = defaultdict(int)
+    for pr in prs:
+        if pr.get("merged_at"):
+            user = pr["user"]["login"]
+            contributions[user] += 1
+    return contributions
+
+
+# Categorize contributors by tier
+def categorize_contributors(contributions):
+    tiers = {tier: [] for tier in TIERS}
+    for user, count in contributions.items():
+        for tier, threshold in TIERS.items():
+            if count >= threshold:
+                tiers[tier].append((user, count))
+                break
+    return tiers
+
+
+# Generate Shieldify badge
+def generate_badge(user, tier):
+    badge_url = f"https://img.shields.io/badge/{user.replace('-', '--')}-{tier.replace(' ', '%20')}-brightgreen"
+    return f"![{user} Badge]({badge_url})"
+
+
+# Generate CONTRIBUTORS.md content
+def generate_contributors_md(tiers):
+    lines = ["# Contributors\n"]
+    for tier, contributors in tiers.items():
+        if contributors:
+            lines.append(f"## {tier}\n")
+            for user, count in sorted(contributors, key=lambda x: x[1], reverse=True):
+                badge = generate_badge(user, tier)
+                lines.append(f"- {badge} ({count} merged PRs)\n")
+    return "\n".join(lines)
+
+
+# Write the CONTRIBUTORS.md file
+def write_contributors_file(content):
+    with open(CONTRIBUTORS_FILE, "w") as file:
+        file.write(content)
+
+
+def main():
+    prs = get_merged_prs()
+    contributions = count_contributions(prs)
+    tiers = categorize_contributors(contributions)
+    content = generate_contributors_md(tiers)
+    write_contributors_file(content)
+    print(f"{CONTRIBUTORS_FILE} generated successfully.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces two new files:  

**1. generate_contributors.py:**
- Automates the process of generating a CONTRIBUTORS.md file based on merged pull requests in the pyupio/safety repository.
- Uses the GitHub API to fetch closed and merged PRs and categorizes contributors into three tiers:
   - Valued Contributor (10+ PRs)
   - Frequent Contributor (5-9 PRs)
   - First Contributor (1-4 PRs)
- Generates personalized Shields.io badges for each contributor and lists them under the appropriate tier in CONTRIBUTORS.md.
   - Each badge indicates the contributor's username and tier.  

**2. CONTRIBUTORS.md:**
- Contains a categorized list of contributors with badges based on their contribution levels.
- This file will be automatically updated by running generate_contributors.py to reflect the latest contributions.
This addition aims to recognize and showcase contributors in a visually engaging way while encouraging further community involvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new section in the `CONTRIBUTORS.md` file to acknowledge contributors with badges, enhancing community recognition.
	- Automated generation of the `CONTRIBUTORS.md` file to streamline contributor acknowledgment based on merged pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->