### PR TITLE
fix/internal-server-error

### DIFF
--- a/safety/scan/command.py
+++ b/safety/scan/command.py
@@ -191,8 +191,8 @@ def generate_updates_arguments() -> List:
                           "ignore_unknown_options": True},
                           )
 @handle_cmd_exception
-@inject_metadata
 @scan_project_command_init
+@inject_metadata
 def scan(ctx: typer.Context,
          target: Annotated[
              Path,


### PR DESCRIPTION
### **Resolves:**

**Steps to Reproduce**

Open terminal

Run safety scan

Log in via Google sign-in (regular non-incognito tab)

**Current Behavior**

The safety scan appears to start normally but fails to complete, returning the following error:

Sorry, something went wrong. Safety CLI can not connect to the server. Our engineers are working quickly to resolve the issue. Reason: Internal Server Error - {"detail":"An error occurred while creating the scan."}

**Expected Behavior**

The safety scan should complete successfully without returning an error.