### PR TITLE
fix/safety error when scan is run without being authenticated

### DIFF
--- a/safety/scan/command.py
+++ b/safety/scan/command.py
@@ -246,6 +246,9 @@ def scan(ctx: typer.Context,
     """
     Scans a project (defaulted to the current directory) for supply-chain security and configuration issues
     """
+    
+    if not ctx.obj.metadata.authenticated:
+        raise SafetyError("Authentication required. Please run 'safety auth login' to authenticate before using this command.")
 
     # Generate update arguments if apply updates option is enabled
     fixes_target = []
@@ -288,14 +291,11 @@ def scan(ctx: typer.Context,
     target_ecosystems = ", ".join([member.value for member in ecosystems])
     wait_msg = f"Analyzing {target_ecosystems} files and environments for security findings"
 
-    import time
-
     files: List[FileModel] = []
 
     config = ctx.obj.config
 
     count = 0
-    ignored = set()
 
     affected_count = 0
     dependency_vuln_detected = False


### PR DESCRIPTION
### Resolves:
In the rare case safety reaches the scan function without the user being authenticated it will raise a SafetyError.
![image](https://github.com/user-attachments/assets/2704887a-8619-4b51-97af-a44063cc9fad)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an authentication check for the scan command, requiring users to authenticate before executing scans.
  
- **Bug Fixes**
	- Removed an unused import statement for improved code cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->