### PR TITLE
chore/update-safety-schemas-version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     rich
     typer
     pydantic>=1.10.12
-    safety_schemas>=0.0.4
+    safety_schemas>=0.0.8
     typing-extensions>=4.7.1
     filelock~=3.12.2
     psutil~=6.0.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -17,7 +17,7 @@ Authlib>=1.2.0
 rich
 typer
 pydantic>=1.10.12
-safety_schemas>=0.0.4
+safety_schemas>=0.0.8
 typing-extensions>=4.7.1
 filelock~=3.12.2
 psutil~=6.0.0


### PR DESCRIPTION
With the new pyproject.toml support, we now must be using safety-schemas version >0.0.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version requirement for the `safety_schemas` package to ensure access to the latest features and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->