### PR TITLE
fix:jupyter notebook rich format removal

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,16 @@
             "console": "integratedTerminal"
         },
         {
+            "name": "Safety Auth Login --headless",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "safety",
+            "args": [
+                "auth","login","--headless"
+            ],
+            "console": "integratedTerminal"
+        },
+        {
             "name": "Safety Auth Logout",
             "type": "debugpy",
             "request": "launch",

--- a/safety/auth/utils.py
+++ b/safety/auth/utils.py
@@ -1,5 +1,7 @@
+from functools import lru_cache
 import json
 import logging
+import sys
 from typing import Any, Optional, Dict, Callable, Tuple
 from authlib.integrations.requests_client import OAuth2Session
 from authlib.integrations.base_client.errors import OAuthError
@@ -425,3 +427,99 @@ class S3PresignedAdapter(HTTPAdapter):
         """
         request.headers.pop("Authorization", None)
         return super().send(request, **kwargs)
+    
+    
+from functools import lru_cache
+
+@lru_cache(maxsize=1)
+def is_jupyter_notebook() -> bool:
+    """
+    Detects if the code is running in a Jupyter notebook environment, including
+    various cloud-hosted Jupyter notebooks.
+
+    Returns:
+        bool: True if the environment is identified as a Jupyter notebook (or 
+              equivalent cloud-based environment), False otherwise.
+
+    Supported environments:
+    - Google Colab
+    - Amazon SageMaker
+    - Azure Notebooks
+    - Kaggle Notebooks
+    - Databricks Notebooks
+    - Datalore by JetBrains
+    - Paperspace Gradient Notebooks
+    - Classic Jupyter Notebook and JupyterLab
+
+    Detection is done by attempting to import environment-specific packages:
+    - Google Colab: `google.colab`
+    - Amazon SageMaker: `sagemaker`
+    - Azure Notebooks: `azureml`
+    - Kaggle Notebooks: `kaggle`
+    - Databricks Notebooks: `dbutils`
+    - Datalore: `datalore`
+    - Paperspace Gradient: `gradient`
+    - Classic Jupyter: Checks if 'IPKernelApp' is in IPython config.
+
+    Example:
+        >>> is_jupyter_notebook()
+        True
+    """
+    try:
+        # Detect Google Colab
+        import google.colab
+        return True
+    except ImportError:
+        pass
+
+    try:
+        # Detect Amazon SageMaker
+        import sagemaker
+        return True
+    except ImportError:
+        pass
+
+    try:
+        # Detect Azure Notebooks
+        import azureml
+        return True
+    except ImportError:
+        pass
+
+    try:
+        # Detect Kaggle Notebooks
+        import kaggle
+        return True
+    except ImportError:
+        pass
+
+    try:
+        # Detect Databricks
+        import dbutils
+        return True
+    except ImportError:
+        pass
+
+    try:
+        # Detect Datalore
+        import datalore
+        return True
+    except ImportError:
+        pass
+
+    try:
+        # Detect Paperspace Gradient Notebooks
+        import gradient
+        return True
+    except ImportError:
+        pass
+
+    try:
+        # Detect classic Jupyter Notebook, JupyterLab, and other IPython kernel-based environments
+        from IPython import get_ipython
+        if 'IPKernelApp' in get_ipython().config:
+            return True
+    except:
+        pass
+
+    return False


### PR DESCRIPTION
## Description

When safety auth is used with the `--headless`arg within a jyupter notebook, user's cannot see the url link to copy and added a disclaimer for line breaks splitting the url.

```
Copy and paste this URL into your browser:
⚠️ Ensure there are no extra spaces, especially at line breaks, as they may break the link.
https://example.com/cli/auth?response_type=code&client_id=XXXXXX&redirect_uri=https%3A%2F%2Fexample.com%2Fcli%2Fcallback&scope=openid+email+profile+offline_access&state=XXXXXX&sign_up=False&locale=en&ensure_auth=False&headless=True&code_challenge=XXXXXX&code_challenge_method=S256
Paste the response here:
```
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- [ ] Tests added or updated
- [x] No tests required


## Checklist

- [x] Code is well-documented
- [x] Changelog is updated (if needed)
- [x] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new debugging configuration for "Safety Auth Login --headless" to streamline the login process.
	- Added a function to check if the code is running in a Jupyter Notebook environment.

- **Bug Fixes**
	- Enhanced error handling and message formatting during the authentication process for clearer output.
	- Improved robustness in processing authentication callbacks and managing connection timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->