### PR TITLE
feat: api keys now work without specifying the env

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,6 +33,16 @@
             "console": "integratedTerminal"
         },
         {
+            "name": "Safety Scan API Key",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "safety",
+            "args": [
+                "--key","ADD-YOUR-API-KEY", "scan"
+            ],
+            "console": "integratedTerminal"
+        },
+        {
             "name": "Safety License",
             "type": "debugpy",
             "request": "launch",

--- a/safety/cli.py
+++ b/safety/cli.py
@@ -644,9 +644,6 @@ def validate(ctx, name, version, path):
               cls=DependentOption,
               required_options=['organization_id'],
               help=CLI_CONFIGURE_ORGANIZATION_NAME)
-@click.option("--stage", "-stg", multiple=False, default=Stage.development.value,
-              type=click.Choice([stage.value for stage in Stage]),
-              help="The project development stage to be tied to the current device.")
 @click.option("--save-to-system/--save-to-user", default=False, is_flag=True,
               help=CLI_CONFIGURE_SAVE_TO_SYSTEM)
 @click.pass_context

--- a/safety/scan/constants.py
+++ b/safety/scan/constants.py
@@ -60,7 +60,7 @@ _CLI_PROXY_TIP_HELP
 CLI_KEY_HELP = "The API key required for cicd stage or production stage scans.\n\n" \
 "[nhc]For development stage scans unset the API key and authenticate using [bold]safety auth[/bold].[/nhc]\n\n" \
 "[nhc]Tip: the API key can also be set using the environment variable: SAFETY_API_KEY[/nhc]\n\n"\
-"[bold]Example: safety --key API_KEY --stage cicd scan[/bold]"
+"[bold]Example: safety --key API_KEY scan[/bold]"
 
 CLI_STAGE_HELP = "Assign a development lifecycle stage to your scan (default: development).\n\n" \
 "[nhc]This labels the scan and its findings in Safety Platform with this stage.[/nhc]\n\n" \

--- a/safety/scan/decorators.py
+++ b/safety/scan/decorators.py
@@ -21,7 +21,7 @@ from safety.scan.models import ScanOutput, SystemScanOutput
 from safety.scan.render import print_announcements, print_header, print_project_info, print_wait_policy_download
 from safety.scan.util import GIT
 
-from safety.scan.validators import fail_if_not_allowed_stage, verify_project
+from safety.scan.validators import verify_project
 from safety.util import build_telemetry_data, pluralize
 from safety_schemas.models import MetadataModel, ScanType, ReportSchemaVersion, \
     PolicySource
@@ -69,8 +69,6 @@ def scan_project_command_init(func):
                                         auth=ctx.obj.auth, ctx=ctx)
 
         upload_request_id = kwargs.pop("upload_request_id", None)
-
-        fail_if_not_allowed_stage(ctx=ctx)
 
         # Run the initialize if it was not fired by a system-scan
         if not upload_request_id:
@@ -208,10 +206,6 @@ def scan_system_command_init(func):
 
         console.print()
         print_header(console=console, targets=targets, is_system_scan=True)
-        wait_msg = "Checking authentication and system scan policies"
-
-        with console.status(wait_msg, spinner=DEFAULT_SPINNER):
-            fail_if_not_allowed_stage(ctx=ctx)
 
         if not policy_file_path:
             if SYSTEM_POLICY_FILE.exists():

--- a/safety/scan/validators.py
+++ b/safety/scan/validators.py
@@ -57,27 +57,6 @@ def output_callback(output: ScanOutput) -> str:
     return output.value
 
 
-def fail_if_not_allowed_stage(ctx: typer.Context):
-    """
-    Fail the command if the authentication type is not allowed in the current stage.
-
-    Args:
-        ctx (typer.Context): The context of the Typer command.
-    """
-    if ctx.resilient_parsing:
-        return
-
-    stage = ctx.obj.auth.stage
-    auth_type: AuthenticationType = ctx.obj.auth.client.get_authentication_type()
-
-    if os.getenv("SAFETY_DB_DIR"):
-        return
-
-    if not auth_type.is_allowed_in(stage):
-        raise typer.BadParameter(f"'{auth_type.value}' auth type isn't allowed with " \
-                                 f"the '{stage}' stage.")
-
-
 def save_verified_project(ctx: typer.Context, slug: str, name: Optional[str], project_path: Path, url_path: Optional[str]):
     """
     Save the verified project information to the context and project info file.


### PR DESCRIPTION
## Description
Previously use of an API Key required "--stage cicd" to function, this has be removed.
This is **NOT A BREAKING CHANGE**, users who have "--stage cicd" in their automations will still complete their scans.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- [ ] Tests added or updated
- [ ] No tests required


## Checklist

- [x] Code is well-documented
- [x] Changelog is updated (if needed)
- [x] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed


