### PR TITLE
Migrate to PyPI Trusted Publisher for Automated Package Deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-20.04
 
     if: contains(fromJson('["refs/heads/main", "refs/heads/binaries-fixes"]'), github.ref) || startsWith(github.ref, 'refs/tags')
-    
+
     steps:
       - name: Slack trigger
         uses: slackapi/slack-github-action@v1.23.0
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}      
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   build-binaries:
     needs: test
@@ -84,13 +84,17 @@ jobs:
 
 
   deploy-pypi:
-    needs: build-binaries
-    runs-on: ubuntu-20.04
-
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-
+    needs: build-binaries
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/safety
+    permissions:
+      id-token: write  # Required for trusted publishing
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -101,11 +105,8 @@ jobs:
           pip install build
       - name: Build package
         run: python -m build
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-        with:
-          user: __token__
-          password: ${{ secrets.SAFETY_PYPI_API_TOKEN }}
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   create-gh-release:
     needs: deploy-pypi


### PR DESCRIPTION
## PR Description:
This PR updates the GitHub Action workflow to use PyPI's trusted publisher mechanism for deploying packages. The changes streamline the publishing process by leveraging GitHub's OpenID Connect (OIDC) authentication, eliminating the need for a separate API token.

## Summary of Changes:
- Added id-token: write permission to enable OIDC-based authentication for PyPI trusted publishing.
- Specified the deployment environment with name set to pypi and the URL pointing to the package on PyPI.
- Removed the `__token__` authentication step, as it’s no longer needed with trusted publishing.
These updates align with PyPI's trusted publisher requirements, providing a more secure and simplified deployment process.






