### PR TITLE
feat/add --headless to --help

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -131,6 +131,16 @@
             "console": "integratedTerminal"
         },
         {
+            "name": "Safety --help",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "safety",
+            "args": [
+                "--help"
+            ],
+            "console": "integratedTerminal"
+        },
+        {
             "name": "Run All Tests",
             "type": "debugpy",
             "request": "launch",

--- a/safety/auth/cli.py
+++ b/safety/auth/cli.py
@@ -23,7 +23,7 @@ from safety.auth.server import process_browser_callback
 from ..cli_util import get_command_for, pass_safety_cli_obj, SafetyCLISubGroup
 
 from .constants import MSG_FAIL_LOGIN_AUTHED, MSG_FAIL_REGISTER_AUTHED, MSG_LOGOUT_DONE, MSG_LOGOUT_FAILED, MSG_NON_AUTHENTICATED
-from safety.scan.constants import CLI_AUTH_COMMAND_HELP, DEFAULT_EPILOG, CLI_AUTH_LOGIN_HELP, CLI_AUTH_LOGOUT_HELP, CLI_AUTH_STATUS_HELP
+from safety.scan.constants import CLI_AUTH_COMMAND_HELP, CLI_AUTH_HEADLESS_HELP, DEFAULT_EPILOG, CLI_AUTH_LOGIN_HELP, CLI_AUTH_LOGOUT_HELP, CLI_AUTH_STATUS_HELP
 
 
 from rich.padding import Padding
@@ -124,7 +124,17 @@ def render_successful_login(auth: Auth,
 
 
 @auth_app.command(name=CMD_LOGIN_NAME, help=CLI_AUTH_LOGIN_HELP)
-def login(ctx: typer.Context, headless: bool = False) -> None:
+def login(
+    ctx: typer.Context,
+    headless: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--headless",
+            help=CLI_AUTH_HEADLESS_HELP,
+        )
+    ] = None
+) -> None:
+    headless = headless is True 
     """
     Authenticate Safety CLI with your safetycli.com account using your default browser.
 

--- a/safety/scan/constants.py
+++ b/safety/scan/constants.py
@@ -16,8 +16,16 @@ CLI_MAIN_INTRODUCTION = f"Safety CLI 3 - Vulnerability Scanning for Secure Pytho
 f"Documentation: {CLI_DOCUMENTATION_URL}\n"\
 f"Contact: {CLI_SUPPORT_EMAIL}\n"
 
-CLI_AUTH_COMMAND_HELP = "Authenticate Safety CLI to perform scans. Your default browser will automatically open to https://platform.safetycli.com."\
-"\nExample: safety auth login"
+CLI_AUTH_COMMAND_HELP = (
+    "Authenticate Safety CLI to perform scans. Your default browser will automatically open to "
+    "https://platform.safetycli.com.\n\n"
+    "Example:\n  safety auth login\n\n"
+    "For headless authentication, you will receive a URL to paste into an external browser.\n\n"
+    "Example:\n  safety auth login --headless"
+)
+
+CLI_AUTH_HEADLESS_HELP = "For headless authentication, you will receive a URL to paste into an external browser."
+
 CLI_SCAN_COMMAND_HELP = "Scans a Python project directory."\
 "\nExample: safety scan to scan the current directory"
 CLI_SYSTEM_SCAN_COMMAND_HELP = "\\[beta] Run a comprehensive scan for packages and vulnerabilities across your entire machine/environment."\
@@ -71,7 +79,6 @@ CLI_DEBUG_HELP = "Enable debug mode for detailed output.\n\n" \
 
 CLI_DISABLE_OPTIONAL_TELEMETRY_DATA_HELP = "Opt-out of sending optional telemetry data. Anonymized telemetry data will remain.\n\n" \
 "[bold]Example: safety --disable-optional-telemetry scan[/bold]"
-
 
 # Scan Help options
 SCAN_POLICY_FILE_HELP = "Use a local policy file to configure the scan.\n\n" \


### PR DESCRIPTION
## Description

Adding --headless info to safety --help.
![image](https://github.com/user-attachments/assets/e2aa2219-2c6e-41df-9cce-e2aedc98cac7)
Added --headless into to safety auth login --help
![image](https://github.com/user-attachments/assets/7ff6fbdf-fda6-436e-852b-a2e8ee6e438c)


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):


## Testing

- [ ] Tests added or updated
- [x] No tests required




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new debugging configuration for the safety module, allowing users to access help documentation directly from the integrated terminal.
	- Added a `headless` option to the `login` command, enabling users to run the command in headless mode.

- **Improvements**
	- Enhanced help text for command-line interface (CLI) commands, providing clearer instructions and improved readability.
	- Updated the `CLI_AUTH_COMMAND_HELP` to include details on headless authentication and formatted for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->