### PR TITLE
feature/add-branch-name

### DIFF
--- a/safety/cli_util.py
+++ b/safety/cli_util.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 import logging
+import subprocess
 import sys
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple, Union
 import click
@@ -373,7 +374,7 @@ def format_main_help(obj: Union[click.Command, click.Group],
     from typer.rich_utils import highlighter, STYLE_USAGE_COMMAND, \
         ARGUMENTS_PANEL_TITLE, OPTIONS_PANEL_TITLE, \
             COMMANDS_PANEL_TITLE
-  
+
     from rich.align import Align
     from rich.padding import Padding
     from rich.console import Console
@@ -794,3 +795,20 @@ def handle_cmd_exception(func):
             output_exception(exception, exit_code_output=True)
 
     return inner
+
+def get_git_branch_name() -> Optional[str]:
+    """
+    Retrieves the current Git branch name.
+
+    Returns:
+        str: The current Git branch name, or None if it cannot be determined.
+    """
+    try:
+        branch_name = subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True
+        ).strip()
+        return branch_name if branch_name else None
+    except Exception:
+        return None


### PR DESCRIPTION
**Summary:**
This PR updates the Project dashboard link generation to include the current Git branch name as a query parameter (?branch=<branch_name>). If the branch name cannot be determined (e.g., not in a Git repository), the link defaults to the original behavior without the query parameter.

**Changes Made:**

Added functionality to fetch the current Git branch using git rev-parse --abbrev-ref HEAD.
Appended the branch name as a URL-encoded query parameter to the project dashboard link.
Ensured fallback to the original URL format if the branch name is unavailable.
Example Output:

**With branch name:**
`https://platform.safetycli.com/projects/<project_id>/findings?branch=feature%2Fexample-branch`
**Without branch name:**
`https://platform.safetycli.com/projects/<project_id>/findings`

<img width="625" alt="image" src="https://github.com/user-attachments/assets/82b7c857-9404-4ed2-8509-1aab0daf406a">