### PR TITLE
Allow later versions of filelock, psutil - unblock safety upgrades

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,8 +52,8 @@ install_requires =
     pydantic>=1.10.12
     safety_schemas>=0.0.8
     typing-extensions>=4.7.1
-    filelock~=3.12.2
-    psutil~=6.0.0
+    filelock>=3.12.2
+    psutil>=6.0.0
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
## Description
filelock dependency was introduced in July 4, 2024. However the pinned version was already outdated at that time.

This means that projects that had requirement files where filelock had already been upgraded to the latest are now stuck with safety 3.2.3 (the last one released without the new dependency).

The commit adding the dependency makes no case for pinning the specific version. So it looks more like an oversight, and allowing later versions should work.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): Dependencies fix.

## Related Issues

Problem introduced by #544.

## Testing

- [ ] Tests added or updated
- [x] No tests required

<!-- Briefly describe the testing that was done. Include steps to manually test or reference automated tests. -->

## Checklist

- [ ] Code is well-documented
- [ ] Changelog is updated (if needed)
- [ ] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes

<!-- Any additional notes or comments to help the reviewer. -->
