### PR TITLE
Add CVE Details and Single-Key Filtering for JSON Output in safety scan

### DIFF
--- a/tests/scan/test_command.py
+++ b/tests/scan/test_command.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+
 from unittest.mock import patch, Mock
 from click.testing import CliRunner
 from safety.cli import cli
@@ -13,7 +14,7 @@ class TestScanCommand(unittest.TestCase):
         self.runner = CliRunner(mix_stderr=False)
         self.dirname = os.path.dirname(__file__)
 
-    def test_scan(self):    
+    def test_scan(self):
         result = self.runner.invoke(cli, ["--stage", "cicd", "scan", "--target", self.dirname, "--output", "json"])
         self.assertEqual(result.exit_code, 1)
 
@@ -22,4 +23,3 @@ class TestScanCommand(unittest.TestCase):
 
         result = self.runner.invoke(cli, ["--stage", "cicd", "scan", "--target", self.dirname, "--output", "screen"])
         self.assertEqual(result.exit_code, 1)
-


### PR DESCRIPTION
This PR introduces the following enhancements to the safety scan command:

**1. CVE Details in Detailed JSON Output**
* Added a new section, cve_details, to the JSON output when --detailed-output  is enabled and output format is specified to json.
* The cve_details section provides comprehensive information about CVEs, including affected packages, severity, CVE IDs, and advisory links.

**2. Single-Key Filtering for JSON Output**
* Implemented the ability to filter the JSON output by a single top-level key using the --filter option.
* Users can now focus on specific sections of the report, such as meta or cve_details, simplifying the output for targeted use cases.

**3. Improved Report Processing**
* Encapsulated the filtering logic into a reusable helper function, filter_json_keys, improving maintainability and readability.

**Testing**
* Manually tested JSON output with and without the --filter option to ensure correctness.
* Verified that:
    * JSON output includes cve_details only when --detailed-output is enabled.
    * The --filter option correctly outputs only the specified top-level key.

**Usage Examples**
* `python -m safety scan --detailed-output --output json`: Includes the new cve_details section in the JSON output.
* `python -m safety scan --detailed-output --output json --filter cve_details`: Outputs only the cve_details section.
* `python -m safety scan --detailed-output --output json --filter meta`: Outputs only the meta section.

These changes enhance the usability of the safety scan command by providing more actionable data and allowing users to filter output for specific use cases.
