### PR TITLE
fix: no proper handling of JSON server errors

### DIFF
--- a/safety/errors.py
+++ b/safety/errors.py
@@ -281,7 +281,6 @@ class ServerError(DatabaseFetchError):
     """
     def __init__(self, reason: Optional[str] = None,
                  message: str = "Sorry, something went wrong.\n"
-                                "Safety CLI cannot connect to the server.\n"
                                 "Our engineers are working quickly to resolve the issue."):
         info = f" Reason: {reason}"
         self.message = message + (info if reason else "")

--- a/safety/scan/render.py
+++ b/safety/scan/render.py
@@ -303,7 +303,7 @@ def print_wait_project_verification(console: Console, project_id: str, closure: 
             LOG.exception(f'Unable to verify the project, reason: {e}')
             reason = "We are currently unable to verify the project, " \
                 "and it is necessary to link the scan to a specific " \
-                    f"project. Reason: {e}"
+                    f"project. \n\nAdditional Information: \n{e}"
             raise SafetyException(message=reason)
 
         if not status:

--- a/tests/auth/test_auth_utils.py
+++ b/tests/auth/test_auth_utils.py
@@ -1,8 +1,10 @@
 import unittest
 from unittest.mock import MagicMock, Mock, patch, call
-from safety.auth.utils import initialize
+
+from safety.auth.utils import initialize, extract_detail, FeatureType, \
+    str_to_bool, get_config_setting, save_flags_config
 from safety.errors import InvalidCredentialError
-from safety.auth.utils import FeatureType, str_to_bool, get_config_setting, save_flags_config
+
 
 class TestUtils(unittest.TestCase):
 
@@ -137,3 +139,24 @@ class TestUtils(unittest.TestCase):
             
             # Verify number of calls matches number of features
             self.assertEqual(mock_setattr.call_count, len(FeatureType))
+
+    def test_extract_detail(self):
+        # Test valid JSON with detail
+        response = Mock()
+        response.json.return_value = {"detail": "Error message"}
+        detail = extract_detail(response)
+        self.assertEqual(detail, "Error message")
+
+        # Test valid JSON without detail
+        response.json.return_value = {"message": "Something else"}
+        detail = extract_detail(response)
+        self.assertIsNone(detail)
+
+        # Test invalid JSON
+        response.json.side_effect = ValueError()
+        detail = extract_detail(response)
+        self.assertIsNone(detail)
+
+        # Test empty response
+        response.json.side_effect = None
+        response.json.return_value = {}


### PR DESCRIPTION
On server errors with JSON responses, the CLI was using response.text instead of response.json() to get the detail, causing string formatting conflicts. Now, it properly parses JSON responses before error handling.