### PR TITLE
chore: add a refresh notice utility script and update the NOTICE file

### DIFF
--- a/LICENSES/NOTICE.md
+++ b/LICENSES/NOTICE.md
@@ -1,72 +1,40 @@
-| Name               | Version         | License                                                                                          |
-|--------------------|-----------------|--------------------------------------------------------------------------------------------------|
-| Authlib            | 1.3.1           | BSD License                                                                                      |
-| Jinja2             | 3.1.4           | BSD License                                                                                      |
-| MarkupSafe         | 2.1.5           | BSD License                                                                                      |
-| Pygments           | 2.18.0          | BSD License                                                                                      |
-| annotated-types    | 0.7.0           | MIT License                                                                                      |
-| backports.tarfile  | 1.2.0           | MIT License                                                                                      |
-| build              | 1.2.1           | MIT License                                                                                      |
-| cachetools         | 5.3.3           | MIT License                                                                                      |
-| certifi            | 2024.7.4        | Mozilla Public License 2.0 (MPL 2.0)                                                             |
-| cffi               | 1.17.0          | MIT License                                                                                      |
-| chardet            | 5.2.0           | GNU Lesser General Public License v2 or later (LGPLv2+)                                          |
-| charset-normalizer | 3.3.2           | MIT License                                                                                      |
-| click              | 8.1.7           | BSD License                                                                                      |
-| colorama           | 0.4.6           | BSD License                                                                                      |
-| coverage           | 7.5.4           | Apache Software License                                                                          |
-| cryptography       | 43.0.0          | Apache Software License; BSD License                                                             |
-| distlib            | 0.3.8           | Python Software Foundation License                                                               |
-| docutils           | 0.21.2          | BSD License; GNU General Public License (GPL); Public Domain; Python Software Foundation License |
-| dparse             | 0.6.4           | MIT License                                                                                      |
-| filelock           | 3.12.4          | The Unlicense (Unlicense)                                                                        |
-| idna               | 3.7             | BSD License                                                                                      |
-| importlib_metadata | 8.4.0           | Apache Software License                                                                          |
-| iniconfig          | 2.0.0           | MIT License                                                                                      |
-| install            | 1.3.5           | MIT License                                                                                      |
-| jaraco.classes     | 3.4.0           | MIT License                                                                                      |
-| jaraco.context     | 6.0.1           | MIT License                                                                                      |
-| jaraco.functools   | 4.0.2           | MIT License                                                                                      |
-| keyring            | 25.3.0          | MIT License                                                                                      |
-| markdown-it-py     | 3.0.0           | MIT License                                                                                      |
-| marshmallow        | 3.21.3          | MIT License                                                                                      |
-| mdurl              | 0.1.2           | MIT License                                                                                      |
-| more-itertools     | 10.4.0          | MIT License                                                                                      |
-| mypy               | 1.10.1          | MIT License                                                                                      |
-| mypy-extensions    | 1.0.0           | MIT License                                                                                      |
-| nh3                | 0.2.18          | MIT                                                                                              |
-| packaging          | 24.1            | Apache Software License; BSD License                                                             |
-| pkginfo            | 1.10.0          | MIT License                                                                                      |
-| platformdirs       | 4.2.2           | MIT License                                                                                      |
-| pluggy             | 1.5.0           | MIT License                                                                                      |
-| psutil             | 6.0.0           | BSD License                                                                                      |
-| pycparser          | 2.22            | BSD License                                                                                      |
-| pydantic           | 2.8.2           | MIT License                                                                                      |
-| pydantic_core      | 2.20.1          | MIT License                                                                                      |
-| pyproject-api      | 1.7.1           | MIT License                                                                                      |
-| pyproject_hooks    | 1.1.0           | MIT License                                                                                      |
-| pytest             | 7.4.4           | MIT License                                                                                      |
-| pytest-cov         | 4.1.0           | MIT License                                                                                      |
-| readme_renderer    | 44.0            | Apache Software License                                                                          |
-| requests           | 2.32.3          | Apache Software License                                                                          |
-| requests-toolbelt  | 1.0.0           | Apache Software License                                                                          |
-| rfc3986            | 2.0.0           | Apache Software License                                                                          |
-| rich               | 13.7.1          | MIT License                                                                                      |
-| ruamel.yaml        | 0.18.6          | MIT License                                                                                      |
-| ruamel.yaml.clib   | 0.2.8           | MIT License                                                                                      |
-| safety             | 3.2.5           | MIT License                                                                                      |
-| safety-schemas     | 0.0.3           | MIT License                                                                                      |
-| shellingham        | 1.5.4           | ISC License (ISCL)                                                                               |
-| toml               | 0.10.2          | MIT License                                                                                      |
-| tox                | 4.15.1          | MIT License                                                                                      |
-| twine              | 5.1.1           | Apache Software License                                                                          |
-| typer              | 0.12.3          | MIT License                                                                                      |
-| types-Pygments     | 2.18.0.20240506 | Apache Software License                                                                          |
-| types-colorama     | 0.4.15.20240311 | Apache Software License                                                                          |
-| types-docutils     | 0.21.0.20240708 | Apache Software License                                                                          |
-| types-requests     | 2.32.0.20240622 | Apache Software License                                                                          |
-| types-setuptools   | 70.2.0.20240704 | Apache Software License                                                                          |
-| typing_extensions  | 4.12.2          | Python Software Foundation License                                                               |
-| urllib3            | 2.2.2           | MIT License                                                                                      |
-| virtualenv         | 20.26.3         | MIT License                                                                                      |
-| zipp               | 3.20.0          | MIT License                                                                                      |
+# Package Licenses
+
+| Name | Version | License |
+|------|---------|----------|
+| annotated-types | 0.7.0 | MIT License |
+| authlib | 1.4.0 | BSD-3-Clause |
+| certifi | 2024.12.14 | MPL-2.0 |
+| cffi | 1.17.1 | MIT |
+| charset-normalizer | 3.4.1 | MIT |
+| click | 8.1.8 | BSD License |
+| cryptography | 44.0.0 | Apache-2.0 OR BSD-3-Clause |
+| dparse | 0.6.4 | MIT license |
+| filelock | 3.16.1 | Unlicense |
+| idna | 3.10 | BSD License |
+| jinja2 | 3.1.5 | BSD License |
+| joblib | 1.4.2 | BSD 3-Clause |
+| markdown-it-py | 3.0.0 | MIT License |
+| markupsafe | 3.0.2 | BSD License |
+| marshmallow | 3.23.3 | MIT License |
+| mdurl | 0.1.2 | MIT License |
+| nltk | 3.9.1 | Apache License, Version 2.0 |
+| packaging | 24.2 | Apache Software License |
+| psutil | 6.1.1 | BSD-3-Clause |
+| pycparser | 2.22 | BSD-3-Clause |
+| pydantic | 2.9.2 | MIT |
+| pydantic-core | 2.23.4 | MIT |
+| pygments | 2.18.0 | BSD-2-Clause |
+| regex | 2024.11.6 | Apache Software License |
+| requests | 2.32.3 | Apache-2.0 |
+| rich | 13.9.4 | MIT |
+| ruamel-yaml | 0.18.8 | MIT license |
+| ruamel-yaml-clib | 0.2.12 | MIT |
+| safety | 3.3.0 | MIT |
+| safety-schemas | 0.0.11 | MIT |
+| setuptools | 75.8.0 | MIT License |
+| shellingham | 1.5.4 | ISC License |
+| tqdm | 4.67.1 | MPL-2.0 AND MIT |
+| typer | 0.15.1 | MIT License |
+| typing-extensions | 4.12.2 | Python Software Foundation License |
+| urllib3 | 2.3.0 | MIT License |

--- a/refresh_notice.py
+++ b/refresh_notice.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+import importlib.metadata
+from pathlib import Path
+from typing import List, Tuple
+
+def normalize_package_name(name: str) -> str:
+    """Normalize package name to lowercase with hyphens."""
+    return name.lower().replace('_', '-').replace('.', '-')
+
+def get_license_from_classifier(classifiers: List[str]) -> str:
+    """Extract license from classifier if available."""
+    for c in classifiers:
+        if 'License :: OSI Approved ::' in c:
+            return c.split('License :: OSI Approved :: ')[-1]
+    return ''
+
+def get_license(dist) -> str:
+    """Get license information from package metadata."""
+    classifiers = dist.metadata.get_all('Classifier') or []
+    classifier_license = get_license_from_classifier(classifiers)
+    
+    # Get direct license field
+    license = dist.metadata.get('License', '')
+    
+    # If license is too long (probably full license text) and we have a classifier, use classifier
+    if len(license) > 100 and classifier_license:
+        return classifier_license
+    
+    # Try License field first
+    if license:
+        return license
+    
+    # Try License-Expression
+    if dist.metadata.get('License-Expression'):
+        return dist.metadata['License-Expression']
+    
+    # Use classifier license if available
+    if classifier_license:
+        return classifier_license
+            
+    return 'License not found'
+
+def get_all_packages() -> List[Tuple[str, str, str]]:
+    """Get all packages with their versions and licenses."""
+    packages = [
+        (normalize_package_name(dist.metadata['Name']), 
+         dist.version, 
+         get_license(dist))
+        for dist in importlib.metadata.distributions()
+    ]
+    return sorted(packages)
+
+def generate_markdown_table(packages: List[Tuple[str, str, str]], output_file: str):
+    """Generate markdown table and save to file."""
+    with open(output_file, 'w') as f:
+        # Write header
+        f.write('# Package Licenses\n\n')
+        f.write('| Name | Version | License |\n')
+        f.write('|------|---------|----------|\n')
+        
+        # Write package rows
+        for name, version, license in packages:
+            # Escape any pipe characters in the license
+            license = license.replace('|', '\\|')
+            f.write(f'| {name} | {version} | {license} |\n')
+
+def main():
+    packages = get_all_packages()
+    generate_markdown_table(packages, 'LICENSES/NOTICE.md')
+    print(f"Generated package_licenses.md with {len(packages)} packages")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
With this utility you can refresh the NOTICE.md for all the dependencies required by Safety

Example:
```
uv run --isolated --with safety==3.3.0 python refresh_notice.py
```