### PR TITLE
chore: use the new ci workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![safety](https://cdn.safetycli.com/images/cli_readme_header.png)](https://docs.safetycli.com/)
 
 [![Downloads](https://static.pepy.tech/badge/safety/month)](https://pepy.tech/project/safety)
-![Build Status](https://github.com/pyupio/safety/actions/workflows/main.yml/badge.svg)
+![CI Status](https://github.com/pyupio/safety/actions/workflows/ci.yml/badge.svg)
 ![License](https://img.shields.io/github/license/pyupio/safety)
 ![PyPI Version](https://img.shields.io/pypi/v/safety)
 ![Python Versions](https://img.shields.io/pypi/pyversions/safety)


### PR DESCRIPTION
Our new workflow is `ci.yml`.
