### PR TITLE
fix: patch asyncio to avoid Windows exception on legacy Python versions

### DIFF
--- a/safety/cli.py
+++ b/safety/cli.py
@@ -112,6 +112,8 @@ except ImportError:
     from typing_extensions import Annotated, Optional
 
 
+import safety.asyncio_patch  # noqa: F401
+
 LOG = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Add back the missing patch removed by lint.
