### PR TITLE
feat: include other category in the init scan

### DIFF
--- a/safety/init/command.py
+++ b/safety/init/command.py
@@ -190,6 +190,14 @@ def generate_summary(state: InitScanState, spinner_phase=0):
             "count_attr": "low",
             "spinner_offset": 6,
         },
+        {
+            "name": "OTHER",
+            "icon": "**",
+            "style": "blue",
+            "dim_style": "dim blue",
+            "count_attr": "others",
+            "spinner_offset": 8,
+        },
     ]
 
     # No vulnerabilities case

--- a/safety/scan/init_scan.py
+++ b/safety/scan/init_scan.py
@@ -318,7 +318,7 @@ def init_scan(
                 vulns_count += 1
 
                 # Determine vulnerability severity
-                severity = None
+                severity = severity = VulnerabilitySeverityLabels.UNKNOWN
                 if (
                     hasattr(vuln, "CVE")
                     and vuln.CVE
@@ -327,8 +327,6 @@ def init_scan(
                 ):
                     severity_str = vuln.CVE.cvssv3.get("base_severity", "none").lower()
                     severity = VulnerabilitySeverityLabels(severity_str)
-                elif hasattr(vuln, "severity") and vuln.severity:
-                    severity = vuln.severity.label
 
                 # Count based on severity
                 if severity is VulnerabilitySeverityLabels.CRITICAL:


### PR DESCRIPTION
This displays the other category in the init scan.