### PR TITLE
fix: instantaneous init output

### DIFF
--- a/safety/init/command.py
+++ b/safety/init/command.py
@@ -29,6 +29,7 @@ from safety_schemas.models.events.types import ToolType
 
 from .render import (
     ask_codebase_setup,
+    ask_continue,
     ask_firewall_setup,
     load_emoji,
     progressive_print,
@@ -610,6 +611,10 @@ def do_init(
         completed_tools, all_completed, all_missing, status = setup_firewall(
             ctx, status, org_slug, console
         )
+        console.line()
+        ask_continue(ctx, prompt_user)
+        console.line()
+
     tracker.current_step = InitExitStep.POST_FIREWALL_SETUP
 
     render_header(MSG_SETUP_CODEBASE_TITLE, emoji="🔒")

--- a/safety/init/constants.py
+++ b/safety/init/constants.py
@@ -46,6 +46,8 @@ MSG_SETUP_INCOMPLETE = f"[red bold]x[/red bold] The setup was not completed succ
 MSG_SETUP_PACKAGE_FIREWALL_RESULT = "configured and secured. Safety will analyze package installations for security risks before installation, and warn you if you install vulnerable packages.\n"
 MSG_SETUP_PACKAGE_FIREWALL_NOTE_STATUS = "To see your firewall status, usage and to configure your firewall security settings visit [link]https://platform.safetycli.com/firewall/[/link]"
 
+MSG_SETUP_CONTINUE_PROMPT = "[bold][Press Enter to continue][/bold]"
+
 MSG_SETUP_CODEBASE_TITLE = " Secure Your First Codebase"
 
 MSG_SETUP_CODEBASE_DESCRIPTION = "Safety monitors your codebase for open source dependency vulnerabilities and risk, surfacing reachable vulnerabilities that pose actual risk, and gives you advice on what to fix and how.\n"

--- a/safety/init/render.py
+++ b/safety/init/render.py
@@ -10,6 +10,7 @@ from safety.events.utils.emission import (
 )
 from safety.init.constants import (
     MSG_SETUP_CODEBASE_PROMPT,
+    MSG_SETUP_CONTINUE_PROMPT,
     MSG_SETUP_PACKAGE_FIREWALL_PROMPT,
 )
 
@@ -146,3 +147,30 @@ def ask_codebase_setup(ctx: typer.Context, prompt_user: bool = True) -> bool:
     )
 
     return should_setup_codebase
+
+
+def ask_continue(ctx: typer.Context, prompt_user: bool = True) -> bool:
+    """
+    Ask the user if they want to continue by typing enter
+
+    Args:
+        ctx: The CLI context
+        prompt_user: Whether to prompt the user for input
+
+    Returns:
+        bool: True if the user wants to continue, False otherwise
+    """
+    if prompt_user:
+        return (
+            Prompt.ask(
+                MSG_SETUP_CONTINUE_PROMPT,
+                choices=["y", "Y"],
+                default="y",
+                show_default=False,
+                show_choices=False,
+                console=console,
+            ).lower()
+            == "y"
+        )
+
+    return True


### PR DESCRIPTION
The output was too verbose and instantaneous, so we introduced a pause so the user had time to read what Safety CLI set up in their system.
