### PR TITLE
fix: add missing instructions for terminal activation after safety init

### DIFF
--- a/safety/init/command.py
+++ b/safety/init/command.py
@@ -54,6 +54,7 @@ from safety.init.constants import (
     MSG_COMPLETE_SECURED,
     MSG_COMPLETE_TOOL_SECURED,
     MSG_FIREWALL_UNINSTALL,
+    MSG_LAST_MANUAL_STEP,
     MSG_NO_VULNERABILITIES_FOUND,
     MSG_NO_VULNS_CODEBASE_URL_DESCRIPTION,
     MSG_OPEN_DASHBOARD_PROMPT,
@@ -62,6 +63,7 @@ from safety.init.constants import (
     MSG_SETUP_COMPLETE_TITLE,
     MSG_SETUP_INCOMPLETE,
     MSG_SETUP_NEXT_STEPS,
+    MSG_SETUP_NEXT_STEPS_MANUAL_STEP,
     MSG_SETUP_NEXT_STEPS_NO_PROJECT,
     MSG_SETUP_NEXT_STEPS_NO_VULNS,
     MSG_SETUP_NEXT_STEPS_SUBTITLE,
@@ -679,10 +681,6 @@ def do_init(
 
     is_setup_complete = all_completed and project_scan_state
 
-    if is_setup_complete:
-        typed_print(MSG_SETUP_COMPLETE_SUBTITLE)
-        console.line()
-
     wrap_up_msg = []
 
     if all_completed:
@@ -722,6 +720,12 @@ def do_init(
         progressive_print(wrap_up_msg)
         console.line()
 
+        if is_setup_complete:
+            typed_print(MSG_SETUP_COMPLETE_SUBTITLE)
+            console.line()
+            typed_print(MSG_LAST_MANUAL_STEP)
+            console.line()
+
     render_header(title=MSG_SETUP_NEXT_STEPS_SUBTITLE, emoji="🚀")
     console.line()
 
@@ -735,6 +739,10 @@ def do_init(
     progressive_print(
         [Padding(Text.from_markup(line), (0, 0, 1, 0)) for line in next_steps_msg]
     )
+
+    console.line()
+    typed_print(MSG_SETUP_NEXT_STEPS_MANUAL_STEP, delay=0.04)
+    console.line()
 
     # Emit event for firewall configuration
     emit_firewall_configured(

--- a/safety/init/constants.py
+++ b/safety/init/constants.py
@@ -1,4 +1,7 @@
 # Codebase options
+import sys
+
+
 CODEBASE_INIT_CMD_NAME = "init"
 CODEBASE_INIT_HELP = (
     "[BETA] Used to install Safety Firewall globally, or to initialize a codebase in the current directory."
@@ -66,9 +69,16 @@ MSG_NO_VULNS_CODEBASE_URL_DESCRIPTION = (
 
 MSG_OPEN_DASHBOARD_PROMPT = f"💡 Open this in a new browser window now? {ASK_HINT}"
 
+MSG_COMMAND_TO_RUN = "`source ~/.profile`"
+MSG_LAST_MANUAL_STEP = (
+    "🟡 IMPORTANT: At the end, restart the terminal to activate your Safety configuration."
+    if sys.platform == "win32"
+    else f"🟡 IMPORTANT: Run {MSG_COMMAND_TO_RUN} to activate your Safety configuration."
+)
+
 MSG_SETUP_COMPLETE_TITLE = " Wrap Up"
 
-MSG_SETUP_COMPLETE_SUBTITLE = "Setup complete!"
+MSG_SETUP_COMPLETE_SUBTITLE = "Almost done! Final step:"
 
 MSG_TOOLS_NOT_CONFIGURED = "[bold red]x[/bold red] No package managers configured"
 MSG_CODEBASE_NOT_CONFIGURED = "[bold red]x[/bold red] No codebase configured"
@@ -106,3 +116,9 @@ MSG_SETUP_NEXT_STEPS_NO_PROJECT = (
 )
 
 MSG_SETUP_NEXT_STEPS_NO_VULNS = (MSG_TEAM, MSG_DOCS, MSG_HELP)
+
+MSG_SETUP_NEXT_STEPS_MANUAL_STEP = (
+    "(Don't forget to restart the terminal now!)"
+    if sys.platform == "win32"
+    else f"(Don't forget to run {MSG_COMMAND_TO_RUN} now!)"
+)


### PR DESCRIPTION
Once the safety firewall is set up for the first time, users must either run a source command or restart their terminal to activate it. We failed to include these instructions in the UI copy, causing user confusion when the feature didn't work immediately after running the safety init command.
