### PR TITLE
deps: rm pydantic uppper version bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
   "marshmallow>=3.15.0", # TODO: To be removed
   "packaging>=21.0",
   "psutil~=6.1.0",
-  "pydantic>=2.6.0,<2.10.0",
+  "pydantic>=2.6.0",
   "requests", # TODO: To be replaced by httpx or aiohttp
   "httpx",
   "tenacity",

--- a/safety/safety.py
+++ b/safety/safety.py
@@ -18,7 +18,7 @@ import requests
 from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
 from packaging.version import parse as parse_version, Version
-from pydantic.json import pydantic_encoder
+from pydantic_core import to_jsonable_python
 from filelock import FileLock
 
 from safety_schemas.models import Ecosystem, FileType
@@ -174,7 +174,7 @@ def fetch_database_url(
 
     telemetry_data = {
         'telemetry': json.dumps(build_telemetry_data(telemetry=telemetry),
-                                default=pydantic_encoder)}
+                                default=to_jsonable_python)}
 
     try:
         r = session.get(url=url, timeout=REQUEST_TIMEOUT,


### PR DESCRIPTION
## Description

Remove upper version bound for Pydantic.

There are no less than 7 +1s about this in https://github.com/pyupio/safety/issues/673.

No background in #655 (refs #620) on why the upper bound on pydantic was put in place. Removed.

There were some deprecation warnings... I resolved the `pydantic_encoder` one. Trying to fix the `config` one seems to break `safety_schemas`. I'll let you all handle that one :) https://github.com/pyupio/safety/blob/b1cffbb24f81f2c637e4554675d039710483fa71/safety/formatters/schemas/common.py#L15-L19

```
PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.9/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

tests/test_cli.py: 1 warning
tests/test_safety.py: 9 warnings
`pydantic_encoder` is deprecated, use `pydantic_core.to_jsonable_python` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.9/migration/
    return _iterencode(o, 0)
```

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): dependency version

## Related Issues

Fixes #673

## Testing

- [ ] Tests added or updated
- [x] No tests required

Ran `pytest`.

## Checklist

- [x] Code is well-documented
- [ ] Changelog is updated (if needed)
- [x] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes

<!-- Any additional notes or comments to help the reviewer. -->
