### PR TITLE
fix: missing uninstall option when feature flag is disabled

### DIFF
--- a/safety/cli_util.py
+++ b/safety/cli_util.py
@@ -874,6 +874,7 @@ class SafetyCLILegacyGroup(click.Group):
             for k, v in self.commands.items()
             if v.context_settings.get(CONTEXT_FEATURE_TYPE, None)
             not in disabled_features
+            or k in ["firewall"]
         }
 
     def invoke(self, ctx: click.Context) -> None:


### PR DESCRIPTION
Users need the uninstall command always available.

