### PR TITLE
bug: preventing the branch name to be included in the codebase url

### DIFF
--- a/safety/scan/init_scan.py
+++ b/safety/scan/init_scan.py
@@ -450,8 +450,6 @@ def init_scan(
         scan_id = result.get("uuid")
 
         codebase_url = f"{SAFETY_PLATFORM_URL}{result['url']}"
-        if project.git and (branch := project.git.branch):
-            codebase_url += f"?branch={branch}"
 
     except Exception as e:
         # Emit error status


### PR DESCRIPTION
## Description

Removes the now redundant logic that set the branch in the query parameter part of URL.

<!-- Briefly describe the purpose of this pull request. What changes are introduced, and why? -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## Related Issues

<!-- List any related issues or reference other PRs, if applicable. Example: Fixes #123, Closes #456 -->

## Testing

- [ ] Tests added or updated
- [ ] No tests required

<!-- Briefly describe the testing that was done. Include steps to manually test or reference automated tests. -->

## Checklist

- [ ] Code is well-documented
- [ ] Changelog is updated (if needed)
- [ ] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes

<!-- Any additional notes or comments to help the reviewer. -->
