### PR TITLE
ci: make sure tests run if lint is skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
   matrix:
     if: ${{ always() }}
-    needs: lint
+    needs: ${{ github.event_name != 'schedule' && 'lint' || '' }}
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
Tests aren't running on schedule CI, this PR should fix it.