### PR TITLE
fix: click version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
   "Authlib>=1.2.0",
-  "Click>=8.0.2", # Just to set a minimum version, Typer works with >=8.0.0
+  "Click>=8.0.2,<8.2.0", # Typer works with >=8.0.0,<8.2.0
   "dparse>=0.6.4",
   "filelock~=3.16.1",
   "jinja2>=3.1.0",
@@ -162,7 +162,7 @@ matrix.targets.dependencies = [
     { value = "Click==8.0.2", if = ["typer-minimal"] },
 
     { value = "typer~=0.13", if = ["typer-latest"] },
-    { value = "Click~=8.1", if = ["typer-latest"] }
+    { value = "Click~=8.1.0", if = ["typer-latest"] }
 ]
 
 # Prevent running the OS specific tests locally


### PR DESCRIPTION
`click 8.2.0` broke multiple things; this constraint will prevent new users from falling into the errors.