### PR TITLE
fix: include missing warn for Poetry

### DIFF
--- a/safety/tool/mixins.py
+++ b/safety/tool/mixins.py
@@ -1,0 +1,151 @@
+from typing import Any, List, Protocol, Tuple, Dict, Optional, runtime_checkable
+import typer
+from rich.padding import Padding
+
+from .base import EnvironmentDiffTracker
+
+from safety.console import main_console as console
+from safety.init.render import render_header, progressive_print
+from safety.models import ToolResult
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class AuditableCommand(Protocol):
+    """
+    Protocol defining the contract for classes that can be audited for packages.
+    """
+
+    @property
+    def _diff_tracker(self) -> "EnvironmentDiffTracker":
+        """
+        Provides package tracking functionality.
+        """
+        ...
+
+    @property
+    def _packages(self) -> List[Tuple[str, Optional[str]]]:
+        """
+        Provides the target package list.
+        """
+        ...
+
+
+class InstallationAuditMixin:
+    """
+    Mixin providing installation audit functionality for command classes.
+
+    This mixin can be used by any command class that needs to audit
+    installation and show warnings.
+
+    Classes using this mixin should conform to the AuditableCommand protocol.
+    """
+
+    def render_installation_warnings(
+        self, ctx: typer.Context, packages_audit: Dict[str, Any]
+    ):
+        """
+        Render installation warnings based on package audit results.
+
+        Args:
+            ctx: The typer context
+            packages_audit: pre-fetched audit data
+        """
+
+        warning_messages = []
+        for audited_package in packages_audit.get("audit", {}).get("packages", []):
+            vulnerabilities = audited_package.get("vulnerabilities", {})
+            critical_vulnerabilities = vulnerabilities.get("critical", 0)
+            total_vulnerabilities = 0
+            for count in vulnerabilities.values():
+                total_vulnerabilities += count
+
+            if total_vulnerabilities == 0:
+                continue
+
+            warning_message = f"[[yellow]Warning[/yellow]] {audited_package.get('package_specifier')} contains {total_vulnerabilities} vulnerabilities"
+            if critical_vulnerabilities > 0:
+                warning_message += f", including {critical_vulnerabilities} critical severity vulnerabilities"
+
+            warning_message += "."
+            warning_messages.append(warning_message)
+
+        if len(warning_messages) > 0:
+            console.print()
+            render_header(" Safety Report")
+            progressive_print(warning_messages)
+            console.line()
+
+    def render_package_details(self: "AuditableCommand"):
+        """
+        Render details for installed packages.
+        """
+        for package_name, _ in self._packages:
+            console.print(
+                Padding(
+                    f"Learn more: [link]https://data.safetycli.com/packages/pypi/{package_name}/[/link]",
+                    (0, 0, 0, 1),
+                ),
+                emoji=True,
+            )
+
+    def audit_packages(self, ctx: typer.Context) -> Dict[str, Any]:
+        """
+        Audit packages based on environment diff tracking.
+        Override this method in your command class if needed.
+
+        Args:
+            ctx: The typer context
+
+        Returns:
+            Dict containing audit results
+        """
+        try:
+            # Check if the instance has a diff tracker and can get a diff
+            # Using getattr to avoid lint errors
+            diff_tracker = getattr(self, "_diff_tracker", None)
+            if diff_tracker and hasattr(diff_tracker, "get_diff"):
+                added, _, updated = diff_tracker.get_diff()
+                packages = {**added, **updated}
+
+                if hasattr(ctx.obj, "auth") and hasattr(ctx.obj.auth, "client"):
+                    return ctx.obj.auth.client.audit_packages(
+                        [
+                            f"{package_name}=={version[-1] if isinstance(version, tuple) else version}"
+                            for (package_name, version) in packages.items()
+                        ]
+                    )
+        except Exception:
+            logger.debug("Audit API failed with error", exc_info=True)
+
+        # Always return a dict to satisfy the return type
+        return dict()
+
+    def handle_installation_audit(self, ctx: typer.Context, result: ToolResult):
+        """
+        Handle installation audit and rendering warnings/details.
+        This is an explicit method that can be called from a command's after method.
+
+        Usage example:
+            def after(self, ctx, result):
+                super().after(ctx, result)
+                self.handle_installation_audit(ctx, result)
+
+        Args:
+            ctx: The typer context
+            result: The tool result
+        """
+
+        if not isinstance(self, AuditableCommand):
+            raise TypeError(
+                "handle_installation_audit can only be called on instances of AuditableCommand"
+            )
+
+        packages_audit = self.audit_packages(ctx)
+        self.render_installation_warnings(ctx, packages_audit)
+
+        # If command failed, show package details
+        if not result.process or result.process.returncode != 0:
+            self.render_package_details()

--- a/tests/tool/test_installation_commands.py
+++ b/tests/tool/test_installation_commands.py
@@ -1,0 +1,48 @@
+# type: ignore
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+import typer
+
+from safety.tool.pip.command import PipInstallCommand
+from safety.tool.uv.command import UvInstallCommand
+from safety.tool.poetry.command import PoetryAddCommand
+
+
+class TestInstallationCommandsAudit:
+    """
+    Test suite for verifying installation audit functionality in command classes.
+    """
+
+    def setup_method(self):
+        """
+        Set up test fixtures.
+        """
+        self.ctx = MagicMock(spec=typer.Context)
+        self.ctx.obj = MagicMock()
+        self.result = MagicMock(duration_ms=100, process=MagicMock(returncode=0))
+
+    @pytest.mark.parametrize(
+        "command_class,command_args",
+        [
+            (PipInstallCommand, ["install", "requests"]),
+            (UvInstallCommand, ["pip", "install", "requests"]),
+            (PoetryAddCommand, ["add", "requests"]),
+        ],
+    )
+    @patch("safety.tool.base.BaseCommand._handle_command_result")
+    def test_installation_command_calls_audit(
+        self, mock_handle_result, command_class, command_args
+    ):
+        """
+        Test that all installation commands call handle_installation_audit in after().
+        """
+        command = command_class(command_args)
+
+        with patch.object(
+            command_class, "handle_installation_audit"
+        ) as mock_handle_audit:
+            command.after(self.ctx, self.result)
+
+            mock_handle_audit.assert_called_once_with(self.ctx, self.result)

--- a/tests/tool/test_mixins.py
+++ b/tests/tool/test_mixins.py
@@ -1,0 +1,251 @@
+# type: ignore
+
+import pytest
+from unittest.mock import MagicMock, patch
+from typing import List, Tuple, Optional
+
+import typer
+
+from safety.models import ToolResult
+from safety.tool.mixins import InstallationAuditMixin
+from safety.tool.environment_diff import EnvironmentDiffTracker
+
+
+class MockAuditableCommand(InstallationAuditMixin):
+    """
+    Mock implementation of an auditable command.
+    """
+
+    def __init__(self, packages=None, diff_data=None):
+        self._mock_packages = packages or []
+        self._mock_diff_data = diff_data or ({}, {}, {})
+
+    @property
+    def _diff_tracker(self) -> "EnvironmentDiffTracker":
+        mock_tracker = MagicMock(spec=EnvironmentDiffTracker)
+        mock_tracker.get_diff.return_value = self._mock_diff_data
+        return mock_tracker
+
+    @property
+    def _packages(self) -> List[Tuple[str, Optional[str]]]:
+        return self._mock_packages
+
+
+class TestInstallationAuditMixin:
+    """
+    Test suite for InstallationAuditMixin functionality.
+    """
+
+    def setup_method(self):
+        """
+        Set up test fixtures.
+        """
+        self.ctx = MagicMock(spec=typer.Context)
+        self.ctx.obj = MagicMock()
+        self.ctx.obj.auth = MagicMock()
+        self.ctx.obj.auth.client = MagicMock()
+        self.result = MagicMock(spec=ToolResult)
+        self.result.process = MagicMock()
+        self.result.process.returncode = 0
+        self.result.duration_ms = 100  # Add the missing duration_ms attribute
+
+    @patch("safety.tool.mixins.console")
+    def test_audit_packages_with_diff(self, mock_console):
+        """
+        Test audit_packages method with diff tracker.
+        """
+        added_packages = {"package1": "1.0.0", "package2": "2.0.0"}
+        updated_packages = {"package3": "3.0.0"}
+        diff_data = (added_packages, {}, updated_packages)  # (added, removed, updated)
+
+        command = MockAuditableCommand(diff_data=diff_data)
+        self.ctx.obj.auth.client.audit_packages.return_value = {
+            "audit": {
+                "packages": [
+                    {
+                        "package_specifier": "package1==1.0.0",
+                        "vulnerabilities": {"critical": 2, "high": 1},
+                    }
+                ]
+            }
+        }
+
+        result = command.audit_packages(self.ctx)
+
+        self.ctx.obj.auth.client.audit_packages.assert_called_once()
+        expected_packages = ["package1==1.0.0", "package2==2.0.0", "package3==3.0.0"]
+        actual_packages = self.ctx.obj.auth.client.audit_packages.call_args[0][0]
+        assert sorted(actual_packages) == sorted(expected_packages)
+        assert result == self.ctx.obj.auth.client.audit_packages.return_value
+
+    @patch("safety.tool.mixins.console")
+    def test_audit_packages_with_tuple_version(self, mock_console):
+        """
+        Test audit_packages method with tuple version.
+        """
+        added_packages = {"package1": ("0.9.0", "1.0.0")}
+        diff_data = (added_packages, {}, {})
+
+        command = MockAuditableCommand(diff_data=diff_data)
+        self.ctx.obj.auth.client.audit_packages.return_value = {
+            "audit": {"packages": []}
+        }
+
+        result = command.audit_packages(self.ctx)
+
+        self.ctx.obj.auth.client.audit_packages.assert_called_once_with(
+            ["package1==1.0.0"]
+        )
+        assert result == self.ctx.obj.auth.client.audit_packages.return_value
+
+    @patch("safety.tool.mixins.console")
+    def test_audit_packages_without_auth(self, mock_console):
+        """
+        Test audit_packages method without auth client.
+        """
+        command = MockAuditableCommand()
+        self.ctx.obj.auth = None
+
+        result = command.audit_packages(self.ctx)
+
+        assert result == {}
+
+    @patch("safety.tool.mixins.console")
+    def test_audit_packages_with_exception(self, mock_console):
+        """
+        Test audit_packages method with exception.
+        """
+        command = MockAuditableCommand(diff_data=({"package1": "1.0.0"}, {}, {}))
+        self.ctx.obj.auth.client.audit_packages.side_effect = Exception("API error")
+
+        result = command.audit_packages(self.ctx)
+
+        assert result == {}
+
+    @patch("safety.tool.mixins.console")
+    @patch("safety.tool.mixins.render_header")
+    @patch("safety.tool.mixins.progressive_print")
+    def test_render_installation_warnings_with_vulnerabilities(
+        self, mock_progressive_print, mock_render_header, mock_console
+    ):
+        """
+        Test render_installation_warnings with vulnerability data.
+        """
+        command = MockAuditableCommand()
+        packages_audit = {
+            "audit": {
+                "packages": [
+                    {
+                        "package_specifier": "vulnerable-package==1.0.0",
+                        "vulnerabilities": {"critical": 2, "high": 1, "medium": 3},
+                    },
+                    {
+                        "package_specifier": "safe-package==2.0.0",
+                        "vulnerabilities": {},  # A backend mismatch
+                    },
+                ]
+            }
+        }
+
+        command.render_installation_warnings(self.ctx, packages_audit)
+
+        mock_render_header.assert_called_once_with(" Safety Report")
+        mock_progressive_print.assert_called_once()
+        warning_messages = mock_progressive_print.call_args[0][0]
+        assert len(warning_messages) == 1
+        assert (
+            "vulnerable-package==1.0.0 contains 6 vulnerabilities"
+            in warning_messages[0]
+        )
+        assert "including 2 critical severity vulnerabilities" in warning_messages[0]
+
+    @patch("safety.tool.mixins.console")
+    def test_render_installation_warnings_without_audit_data(self, mock_console):
+        """
+        Test render_installation_warnings without audit data.
+        """
+        command = MockAuditableCommand()
+        command.render_installation_warnings(self.ctx, {})
+        mock_console.print.assert_not_called()
+
+    @patch("safety.tool.mixins.console")
+    def test_render_package_details(self, mock_console):
+        """
+        Test render_package_details method.
+        """
+        packages = [("package1", "1.0.0"), ("package2", None)]
+        command = MockAuditableCommand(packages=packages)
+
+        command.render_package_details()
+
+        assert mock_console.print.call_count == 2
+        for call_args in mock_console.print.call_args_list:
+            padding_arg = call_args[0][0]
+            assert "Learn more: " in str(padding_arg)
+            assert "https://data.safetycli.com/packages/pypi/" in str(padding_arg)
+
+    @patch.object(MockAuditableCommand, "audit_packages")
+    @patch.object(MockAuditableCommand, "render_installation_warnings")
+    @patch.object(MockAuditableCommand, "render_package_details")
+    @patch("safety.tool.base.BaseCommand._perform_diff")
+    @patch("safety.tool.base.BaseCommand._handle_command_result")
+    def test_handle_installation_audit_success(
+        self,
+        mock_handle_result,
+        mock_perform_diff,
+        mock_render_details,
+        mock_render_warnings,
+        mock_audit_packages,
+    ):
+        """
+        Test handle_installation_audit with successful process.
+        """
+        command = MockAuditableCommand()
+        mock_audit_packages.return_value = {"audit": {"packages": []}}
+        self.result.process.returncode = 0
+
+        command.handle_installation_audit(self.ctx, self.result)
+
+        mock_audit_packages.assert_called_once_with(self.ctx)
+        mock_render_warnings.assert_called_once_with(
+            self.ctx, mock_audit_packages.return_value
+        )
+        mock_render_details.assert_not_called()  # Should not be called for successful process
+
+    @patch.object(MockAuditableCommand, "audit_packages")
+    @patch.object(MockAuditableCommand, "render_installation_warnings")
+    @patch.object(MockAuditableCommand, "render_package_details")
+    @patch("safety.tool.base.BaseCommand._perform_diff")
+    @patch("safety.tool.base.BaseCommand._handle_command_result")
+    def test_handle_installation_audit_failure(
+        self,
+        mock_handle_result,
+        mock_perform_diff,
+        mock_render_details,
+        mock_render_warnings,
+        mock_audit_packages,
+    ):
+        """
+        Test handle_installation_audit with failed process.
+        """
+
+        command = MockAuditableCommand()
+        mock_audit_packages.return_value = {"audit": {"packages": []}}
+        self.result.process.returncode = 1  # Non-zero indicates failure
+
+        command.handle_installation_audit(self.ctx, self.result)
+
+        mock_audit_packages.assert_called_once_with(self.ctx)
+        mock_render_warnings.assert_called_once_with(
+            self.ctx, mock_audit_packages.return_value
+        )
+        mock_render_details.assert_called_once()  # Should be called for failed process
+
+    def test_handle_installation_audit_type_error(self):
+        """
+        Test handle_installation_audit with non-AuditableCommand instance.
+        """
+        non_auditable = InstallationAuditMixin()
+
+        with pytest.raises(TypeError):
+            non_auditable.handle_installation_audit(self.ctx, self.result)


### PR DESCRIPTION
The previous warning implementation missed Poetry; this fix unifies the behavior.
