### PR TITLE
fix: encoding issues when reading user UTF-16 and UTF-8-SIG encoded files

### DIFF
--- a/safety/encoding.py
+++ b/safety/encoding.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def detect_encoding(file_path: Path) -> str:
+    """
+    UTF-8 is the most common encoding standard, this is a simple
+    way to improve the support for related Windows based files.
+
+    Handles the most common cases efficiently.
+    """
+    try:
+        with open(file_path, "rb") as f:
+            # Read first 3 bytes for BOM detection
+            bom = f.read(3)
+
+        # Check most common Windows patterns first
+        if bom[:2] in (b"\xff\xfe", b"\xfe\xff"):
+            return "utf-16"
+        elif bom.startswith(b"\xef\xbb\xbf"):
+            return "utf-8-sig"
+
+        return "utf-8"
+    except Exception:
+        logger.exception("Error detecting encoding")
+        return "utf-8"

--- a/safety/tool/pip/command.py
+++ b/safety/tool/pip/command.py
@@ -16,6 +16,7 @@ from safety_schemas.models.events.types import ToolType
 from ..environment_diff import EnvironmentDiffTracker, PipEnvironmentDiffTracker
 from ..mixins import InstallationAuditMixin
 from ..utils import Pip
+from ...encoding import detect_encoding
 
 
 PIP_LOCK = "safety-pip.lock"
@@ -116,7 +117,9 @@ class PipInstallCommand(PipCommand, InstallationAuditMixin):
             ) or self._intention.options.get("r"):
                 req_value = req_opt["value"]
                 if req_value and Path(req_value).is_file():
-                    with open(req_value, "r") as f:
+                    with open(
+                        req_value, "r", encoding=detect_encoding(Path(req_value))
+                    ) as f:
                         fd, tmp_requirements_path = mkstemp(
                             suffix="safety-requirements.txt", text=True
                         )

--- a/safety/tool/pip/main.py
+++ b/safety/tool/pip/main.py
@@ -18,7 +18,7 @@ from safety.tool.resolver import get_unwrapped_command
 
 from safety.console import main_console
 from safety.tool.auth import index_credentials
-
+from ...encoding import detect_encoding
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ class Pip:
             console (Console): Console instance.
         """
 
-        with open(file, "r+") as f:
+        with open(file, "r+", encoding=detect_encoding(file)) as f:
             content = f.read()
 
             repository_url = (

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,0 +1,90 @@
+import tempfile
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from safety.encoding import detect_encoding
+
+
+class TestDetectEncoding:
+    """
+    Tests for the detect_encoding function.
+    """
+
+    def test_utf16_le_detection(self):
+        """
+        Test that UTF-16 LE (Little Endian) encoding is correctly detected.
+        """
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            # UTF-16 LE BOM: \xff\xfe
+            f.write(b"\xff\xfe" + "Hello, world!".encode("utf-16-le")[2:])
+
+        try:
+            encoding = detect_encoding(Path(f.name))
+            assert encoding == "utf-16"
+        finally:
+            os.unlink(f.name)
+
+    def test_utf16_be_detection(self):
+        """
+        Test that UTF-16 BE (Big Endian) encoding is correctly detected.
+        """
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            # UTF-16 BE BOM: \xfe\xff
+            f.write(b"\xfe\xff" + "Hello, world!".encode("utf-16-be")[2:])
+
+        try:
+            encoding = detect_encoding(Path(f.name))
+            assert encoding == "utf-16"
+        finally:
+            os.unlink(f.name)
+
+    def test_utf8_sig_detection(self):
+        """
+        Test that UTF-8 with signature (BOM) is correctly detected.
+        """
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            # UTF-8 with signature BOM: \xef\xbb\xbf
+            f.write(b"\xef\xbb\xbf" + "Hello, world!".encode("utf-8"))
+
+        try:
+            encoding = detect_encoding(Path(f.name))
+            assert encoding == "utf-8-sig"
+        finally:
+            os.unlink(f.name)
+
+    def test_utf8_detection(self):
+        """
+        Test that regular UTF-8 (without BOM) is correctly detected.
+        """
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            # Regular UTF-8 (no BOM)
+            f.write("Hello, world!".encode("utf-8"))
+
+        try:
+            encoding = detect_encoding(Path(f.name))
+            assert encoding == "utf-8"
+        finally:
+            os.unlink(f.name)
+
+    def test_error_handling(self):
+        """
+        Test that errors are properly handled and default encoding is returned.
+        """
+        # Test with a non-existent file
+        non_existent_file = Path("non_existent_file.txt")
+
+        encoding = detect_encoding(non_existent_file)
+        assert encoding == "utf-8"
+
+    def test_exception_logging(self):
+        """
+        Test that exceptions are properly logged.
+        """
+        non_existent_file = Path("non_existent_file.txt")
+
+        with patch("safety.encoding.logger") as mock_logger:
+            encoding = detect_encoding(non_existent_file)
+
+            assert encoding == "utf-8"
+            mock_logger.exception.assert_called_once_with("Error detecting encoding")


### PR DESCRIPTION
This prevents the CLI from crashing when users use UTF-16 and UTF-8-SIG encodings. UTF-16 is mostly used on Windows

For other encodings, Safety CLI will fail.