### PR TITLE
ci: use a newer windows runner image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,7 @@ targets = [
 ]
 os_type = [
   "ubuntu-24.04",
-  "windows-2019",
+  "windows-2022",
   "macos-14",
 ]
 
@@ -226,7 +226,7 @@ targets = [
 ]
 os_type = [
   "ubuntu-24.04",
-  "windows-2019",
+  "windows-2022",
   "macos-14"
 ]
 


### PR DESCRIPTION
GitHub is deprecating the old Windows image, this changes from windows-2019 to windows-2022.

