### PR TITLE
fix: resolve logger warnings

### DIFF
--- a/safety/scan/command.py
+++ b/safety/scan/command.py
@@ -1294,7 +1294,7 @@ def system_scan(
                     continue
 
                 if not project or not project.id:
-                    LOG.warn(
+                    LOG.warning(
                         f"{project_path} parsed but project id is not defined or valid."
                     )
                     continue


### PR DESCRIPTION
## Description
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
This small PR resolves those warnings.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

## Related Issues

<!-- List any related issues or reference other PRs, if applicable. Example: Fixes #123, Closes #456 -->

## Testing

- [ ] Tests added or updated
- [x] No tests required

<!-- Briefly describe the testing that was done. Include steps to manually test or reference automated tests. -->

## Checklist

- [x] Code is well-documented
- [ ] Changelog is updated (if needed)
- [x] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes

<!-- Any additional notes or comments to help the reviewer. -->
