### PR TITLE
fix: set custom user-agent header to all HTTP requests

### DIFF
--- a/safety/alerts/__init__.py
+++ b/safety/alerts/__init__.py
@@ -17,11 +17,15 @@ LOG = logging.getLogger(__name__)
 
 def get_safety_cli_legacy_group():
     from safety.cli_util import SafetyCLILegacyGroup
+
     return SafetyCLILegacyGroup
+
 
 def get_context_settings():
     from safety.cli_util import CommandType
+
     return {CONTEXT_COMMAND_TYPE: CommandType.UTILITY}
+
 
 @dataclass
 class Alert:
@@ -34,21 +38,43 @@ class Alert:
         policy (Any): The policy data.
         requirements_files (Any): The requirements files data.
     """
+
     report: Any
     key: str
     policy: Any = None
     requirements_files: Any = None
 
-@click.group(cls=get_safety_cli_legacy_group(), help=CLI_ALERT_COMMAND_HELP,
-             deprecated=True, context_settings=get_context_settings())
-@click.option('--check-report', help='JSON output of Safety Check to work with.', type=click.File('r'), default=sys.stdin, required=True)
-@click.option("--key", envvar="SAFETY_API_KEY",
-              help="API Key for safetycli.com's vulnerability database. Can be set as SAFETY_API_KEY "
-                   "environment variable.", required=True)
-@click.option("--policy-file", type=SafetyPolicyFile(), default='.safety-policy.yml',
-              help="Define the policy file to be used")
+
+@click.group(
+    cls=get_safety_cli_legacy_group(),
+    help=CLI_ALERT_COMMAND_HELP,
+    deprecated=True,
+    context_settings=get_context_settings(),
+)
+@click.option(
+    "--check-report",
+    help="JSON output of Safety Check to work with.",
+    type=click.File("r"),
+    default=sys.stdin,
+    required=True,
+)
+@click.option(
+    "--key",
+    envvar="SAFETY_API_KEY",
+    help="API Key for safetycli.com's vulnerability database. Can be set as SAFETY_API_KEY "
+    "environment variable.",
+    required=True,
+)
+@click.option(
+    "--policy-file",
+    type=SafetyPolicyFile(),
+    default=".safety-policy.yml",
+    help="Define the policy file to be used",
+)
 @click.pass_context
-def alert(ctx: click.Context, check_report: IO[str], policy_file: SafetyPolicyFile, key: str) -> None:
+def alert(
+    ctx: click.Context, check_report: IO[str], policy_file: SafetyPolicyFile, key: str
+) -> None:
     """
     Command for processing the Safety Check JSON report.
 
@@ -58,23 +84,26 @@ def alert(ctx: click.Context, check_report: IO[str], policy_file: SafetyPolicyFi
         policy_file (SafetyPolicyFile): The policy file to be used.
         key (str): The API key for the safetycli.com vulnerability database.
     """
-    LOG.info('alert started')
-    LOG.info(f'check_report is using stdin: {check_report == sys.stdin}')
+    LOG.info("alert started")
+    LOG.info(f"check_report is using stdin: {check_report == sys.stdin}")
 
     with check_report:
         # TODO: This breaks --help for subcommands
         try:
             safety_report = json.load(check_report)
         except json.decoder.JSONDecodeError as e:
-            LOG.info('Error in the JSON report.')
-            click.secho("Error decoding input JSON: {}".format(e.msg), fg='red')
+            LOG.info("Error in the JSON report.")
+            click.secho("Error decoding input JSON: {}".format(e.msg), fg="red")
             sys.exit(1)
 
-    if not 'report_meta' in safety_report:
-        click.secho("You must pass in a valid Safety Check JSON report", fg='red')
+    if "report_meta" not in safety_report:
+        click.secho("You must pass in a valid Safety Check JSON report", fg="red")
         sys.exit(1)
 
-    ctx.obj = Alert(report=safety_report, policy=policy_file if policy_file else {}, key=key)
+    ctx.obj = Alert(
+        report=safety_report, policy=policy_file if policy_file else {}, key=key
+    )
+
 
 # Adding subcommands for GitHub integration
 alert.add_command(github.github_pr)

--- a/safety/alerts/github.py
+++ b/safety/alerts/github.py
@@ -1,3 +1,4 @@
+# type: ignore
 import itertools
 import logging
 import re
@@ -43,10 +44,15 @@ def delete_branch(repo: Any, branch: str) -> None:
     ref = repo.get_git_ref(f"heads/{branch}")
     ref.delete()
 
+
 @click.command()
-@click.option('--repo', help='GitHub standard repo path (eg, my-org/my-project)')
-@click.option('--token', help='GitHub Access Token')
-@click.option('--base-url', help='Optional custom Base URL, if you\'re using GitHub enterprise', default=None)
+@click.option("--repo", help="GitHub standard repo path (eg, my-org/my-project)")
+@click.option("--token", help="GitHub Access Token")
+@click.option(
+    "--base-url",
+    help="Optional custom Base URL, if you're using GitHub enterprise",
+    default=None,
+)
 @click.pass_obj
 @utils.require_files_report
 def github_pr(obj: Any, repo: str, token: str, base_url: Optional[str]) -> None:
@@ -62,21 +68,24 @@ def github_pr(obj: Any, repo: str, token: str, base_url: Optional[str]) -> None:
         base_url (Optional[str]): Custom base URL for GitHub Enterprise, if applicable.
     """
     if pygithub is None:
-        click.secho("pygithub is not installed. Did you install Safety with GitHub support? Try pip install safety[github]", fg='red')
+        click.secho(
+            "pygithub is not installed. Did you install Safety with GitHub support? Try pip install safety[github]",
+            fg="red",
+        )
         sys.exit(1)
 
     # Load alert configurations from the policy
-    alert = obj.policy.get('alert', {}) or {}
-    security = alert.get('security', {}) or {}
-    config_pr = security.get('github-pr', {}) or {}
+    alert = obj.policy.get("alert", {}) or {}
+    security = alert.get("security", {}) or {}
+    config_pr = security.get("github-pr", {}) or {}
 
-    branch_prefix = config_pr.get('branch-prefix', 'pyup/')
-    pr_prefix = config_pr.get('pr-prefix', '[PyUp] ')
-    assignees = config_pr.get('assignees', [])
-    labels = config_pr.get('labels', ['security'])
-    label_severity = config_pr.get('label-severity', True)
-    ignore_cvss_severity_below = config_pr.get('ignore-cvss-severity-below', 0)
-    ignore_cvss_unknown_severity = config_pr.get('ignore-cvss-unknown-severity', False)
+    branch_prefix = config_pr.get("branch-prefix", "pyup/")
+    pr_prefix = config_pr.get("pr-prefix", "[PyUp] ")
+    assignees = config_pr.get("assignees", [])
+    labels = config_pr.get("labels", ["security"])
+    label_severity = config_pr.get("label-severity", True)
+    ignore_cvss_severity_below = config_pr.get("ignore-cvss-severity-below", 0)
+    ignore_cvss_unknown_severity = config_pr.get("ignore-cvss-unknown-severity", False)
 
     # Authenticate with GitHub
     gh = pygithub.Github(token, **({"base_url": base_url} if base_url else {}))
@@ -90,13 +99,21 @@ def github_pr(obj: Any, repo: str, token: str, base_url: Optional[str]) -> None:
         self_user = "web-flow"
 
     # Collect all remediations from the report
-    req_remediations = list(itertools.chain.from_iterable(
-        rem.get('requirements', {}).values() for pkg_name, rem in obj.report['remediations'].items()))
+    req_remediations = list(
+        itertools.chain.from_iterable(
+            rem.get("requirements", {}).values()
+            for pkg_name, rem in obj.report["remediations"].items()
+        )
+    )
 
     # Get all open pull requests for the repository
-    pulls = repo.get_pulls(state='open', sort='created', base=repo.default_branch)
+    pulls = repo.get_pulls(state="open", sort="created", base=repo.default_branch)
     pending_updates = set(
-        [f"{canonicalize_name(req_rem['requirement']['name'])}{req_rem['requirement']['specifier']}" for req_rem in req_remediations])
+        [
+            f"{canonicalize_name(req_rem['requirement']['name'])}{req_rem['requirement']['specifier']}"
+            for req_rem in req_remediations
+        ]
+    )
 
     created = 0
 
@@ -104,33 +121,48 @@ def github_pr(obj: Any, repo: str, token: str, base_url: Optional[str]) -> None:
     # Iterate over all requirements files and process each remediation
     for name, contents in obj.requirements_files.items():
         raw_contents = contents
-        contents = contents.decode('utf-8') # TODO - encoding?
+        contents = contents.decode("utf-8")  # TODO - encoding?
         parsed_req_file = requirements.RequirementFile(name, contents)
 
         for remediation in req_remediations:
-            pkg = remediation['requirement']['name']
+            pkg = remediation["requirement"]["name"]
             pkg_canonical_name: str = canonicalize_name(pkg)
-            analyzed_spec: str = remediation['requirement']['specifier']
+            analyzed_spec: str = remediation["requirement"]["specifier"]
 
             # Skip remediations without a recommended version
-            if remediation['recommended_version'] is None:
-                LOG.debug(f"The GitHub PR alerter only currently supports remediations that have a recommended_version: {pkg}")
+            if remediation["recommended_version"] is None:
+                LOG.debug(
+                    f"The GitHub PR alerter only currently supports remediations that have a recommended_version: {pkg}"
+                )
                 continue
 
             # We have a single remediation that can have multiple vulnerabilities
             # Find all vulnerabilities associated with the remediation
-            vulns = [x for x in obj.report['vulnerabilities'] if
-                     x['package_name'] == pkg_canonical_name and x['analyzed_requirement']['specifier'] == analyzed_spec]
+            vulns = [
+                x
+                for x in obj.report["vulnerabilities"]
+                if x["package_name"] == pkg_canonical_name
+                and x["analyzed_requirement"]["specifier"] == analyzed_spec
+            ]
 
             # Skip if all vulnerabilities have unknown severity and the ignore flag is set
-            if ignore_cvss_unknown_severity and all(x['severity'] is None for x in vulns):
-                LOG.debug("All vulnerabilities have unknown severity, and ignore_cvss_unknown_severity is set.")
+            if ignore_cvss_unknown_severity and all(
+                x["severity"] is None for x in vulns
+            ):
+                LOG.debug(
+                    "All vulnerabilities have unknown severity, and ignore_cvss_unknown_severity is set."
+                )
                 continue
 
             highest_base_score = 0
             for vuln in vulns:
-                if vuln['severity'] is not None:
-                    highest_base_score = max(highest_base_score, (vuln['severity'].get('cvssv3', {}) or {}).get('base_score', 10))
+                if vuln["severity"] is not None:
+                    highest_base_score = max(
+                        highest_base_score,
+                        (vuln["severity"].get("cvssv3", {}) or {}).get(
+                            "base_score", 10
+                        ),
+                    )
 
             # Skip if none of the vulnerabilities meet the severity threshold
             if ignore_cvss_severity_below:
@@ -138,22 +170,41 @@ def github_pr(obj: Any, repo: str, token: str, base_url: Optional[str]) -> None:
                 for vuln in vulns:
                     # Consider a None severity as a match, since it's controlled by a different flag
                     # If we can't find a base_score but we have severity data, assume it's critical for now.
-                    if vuln['severity'] is None or (vuln['severity'].get('cvssv3', {}) or {}).get('base_score', 10) >= ignore_cvss_severity_below:
+                    if (
+                        vuln["severity"] is None
+                        or (vuln["severity"].get("cvssv3", {}) or {}).get(
+                            "base_score", 10
+                        )
+                        >= ignore_cvss_severity_below
+                    ):
                         at_least_one_match = True
 
                 if not at_least_one_match:
-                    LOG.debug(f"None of the vulnerabilities found have a score greater than or equal to the ignore_cvss_severity_below of {ignore_cvss_severity_below}")
+                    LOG.debug(
+                        f"None of the vulnerabilities found have a score greater than or equal to the ignore_cvss_severity_below of {ignore_cvss_severity_below}"
+                    )
                     continue
 
             for parsed_req in parsed_req_file.requirements:
-                specs = SpecifierSet('>=0') if parsed_req.specs == SpecifierSet('') else parsed_req.specs
+                specs = (
+                    SpecifierSet(">=0")
+                    if parsed_req.specs == SpecifierSet("")
+                    else parsed_req.specs
+                )
 
                 # Check if the requirement matches the remediation
-                if canonicalize_name(parsed_req.name) == pkg_canonical_name and str(specs) == analyzed_spec:
-                    updated_contents = parsed_req.update_version(contents, remediation['recommended_version'])
+                if (
+                    canonicalize_name(parsed_req.name) == pkg_canonical_name
+                    and str(specs) == analyzed_spec
+                ):
+                    updated_contents = parsed_req.update_version(
+                        contents, remediation["recommended_version"]
+                    )
                     pending_updates.discard(f"{pkg_canonical_name}{analyzed_spec}")
 
-                    new_branch = branch_prefix + utils.generate_branch_name(pkg, remediation)
+                    new_branch = branch_prefix + utils.generate_branch_name(
+                        pkg, remediation
+                    )
                     skip_create = False
 
                     # Few possible cases:
@@ -169,15 +220,19 @@ def github_pr(obj: Any, repo: str, token: str, base_url: Optional[str]) -> None:
                         if not pr.head.ref.startswith(branch_prefix):
                             continue
 
-                        authors = [commit.committer.login for commit in pr.get_commits()]
+                        authors = [
+                            commit.committer.login for commit in pr.get_commits()
+                        ]
                         only_us = all([x == self_user for x in authors])
 
                         try:
-                            _, pr_pkg, pr_spec, pr_ver = pr.head.ref.split('/')
+                            _, pr_pkg, pr_spec, pr_ver = pr.head.ref.split("/")
                         except ValueError:
                             # It's possible that something weird has manually been done, so skip that
                             # Skip invalid branch names
-                            LOG.debug('Found an invalid branch name on an open PR, that matches our prefix. Skipping.')
+                            LOG.debug(
+                                "Found an invalid branch name on an open PR, that matches our prefix. Skipping."
+                            )
                             continue
 
                         pr_pkg = canonicalize_name(pr_pkg)
@@ -186,37 +241,58 @@ def github_pr(obj: Any, repo: str, token: str, base_url: Optional[str]) -> None:
                             continue
 
                         # Case 4: An up-to-date PR exists
-                        if pr_pkg == pkg_canonical_name and pr_spec == analyzed_spec and pr_ver == \
-                                remediation['recommended_version'] and pr.mergeable:
-                            LOG.debug(f"An up to date PR #{pr.number} for {pkg} was found, no action will be taken.")
+                        if (
+                            pr_pkg == pkg_canonical_name
+                            and pr_spec == analyzed_spec
+                            and pr_ver == remediation["recommended_version"]
+                            and pr.mergeable
+                        ):
+                            LOG.debug(
+                                f"An up to date PR #{pr.number} for {pkg} was found, no action will be taken."
+                            )
 
                             skip_create = True
                             continue
 
                         if not only_us:
-                            LOG.debug(f"There are other committers on the PR #{pr.number} for {pkg}. No further action will be taken.")
+                            LOG.debug(
+                                f"There are other committers on the PR #{pr.number} for {pkg}. No further action will be taken."
+                            )
                             continue
 
                         # Case 2: An existing PR is out of date
-                        if pr_pkg == pkg_canonical_name and pr_spec == analyzed_spec and pr_ver != \
-                                remediation['recommended_version']:
-                            LOG.debug(f"Closing stale PR #{pr.number} for {pkg} as a newer recommended version became")
+                        if (
+                            pr_pkg == pkg_canonical_name
+                            and pr_spec == analyzed_spec
+                            and pr_ver != remediation["recommended_version"]
+                        ):
+                            LOG.debug(
+                                f"Closing stale PR #{pr.number} for {pkg} as a newer recommended version became"
+                            )
 
-                            pr.create_issue_comment("This PR has been replaced, since a newer recommended version became available.")
-                            pr.edit(state='closed')
+                            pr.create_issue_comment(
+                                "This PR has been replaced, since a newer recommended version became available."
+                            )
+                            pr.edit(state="closed")
                             delete_branch(repo, pr.head.ref)
 
                         # Case 3: An existing PR is not mergeable
                         if not pr.mergeable:
-                            LOG.debug(f"Closing PR #{pr.number} for {pkg} as it has become unmergable and we were the only committer")
+                            LOG.debug(
+                                f"Closing PR #{pr.number} for {pkg} as it has become unmergable and we were the only committer"
+                            )
 
-                            pr.create_issue_comment("This PR has been replaced since it became unmergable.")
-                            pr.edit(state='closed')
+                            pr.create_issue_comment(
+                                "This PR has been replaced since it became unmergable."
+                            )
+                            pr.edit(state="closed")
                             delete_branch(repo, pr.head.ref)
 
                     # Skip if no changes were made
                     if updated_contents == contents:
-                        LOG.debug(f"Couldn't update {pkg} to {remediation['recommended_version']}")
+                        LOG.debug(
+                            f"Couldn't update {pkg} to {remediation['recommended_version']}"
+                        )
                         continue
 
                     # Skip creation if indicated
@@ -227,37 +303,51 @@ def github_pr(obj: Any, repo: str, token: str, base_url: Optional[str]) -> None:
                     try:
                         create_branch(repo, repo.default_branch, new_branch)
                     except pygithub.GithubException as e:
-                        if e.data['message'] == "Reference already exists":
+                        if e.data["message"] == "Reference already exists":
                             # There might be a stale branch. If the bot is the only committer, nuke it.
                             comparison = repo.compare(repo.default_branch, new_branch)
-                            authors = [commit.committer.login for commit in comparison.commits]
+                            authors = [
+                                commit.committer.login for commit in comparison.commits
+                            ]
                             only_us = all([x == self_user for x in authors])
 
                             if only_us:
                                 delete_branch(repo, new_branch)
                                 create_branch(repo, repo.default_branch, new_branch)
                             else:
-                                LOG.debug(f"The branch '{new_branch}' already exists - but there is no matching PR and this branch has committers other than us. This remediation will be skipped.")
+                                LOG.debug(
+                                    f"The branch '{new_branch}' already exists - but there is no matching PR and this branch has committers other than us. This remediation will be skipped."
+                                )
                                 continue
                         else:
                             raise e
 
                     try:
                         repo.update_file(
-                                path=name,
-                                message=utils.generate_commit_message(pkg, remediation),
-                                content=updated_contents,
-                                branch=new_branch,
-                                sha=utils.git_sha1(raw_contents)
-                            )
+                            path=name,
+                            message=utils.generate_commit_message(pkg, remediation),
+                            content=updated_contents,
+                            branch=new_branch,
+                            sha=utils.git_sha1(raw_contents),
+                        )
                     except pygithub.GithubException as e:
-                        if "does not match" in e.data['message']:
-                            click.secho(f"GitHub blocked a commit on our branch to the requirements file, {name}, as the local hash we computed didn't match the version on {repo.default_branch}. Make sure you're running safety against the latest code on your default branch.", fg='red')
+                        if "does not match" in e.data["message"]:
+                            click.secho(
+                                f"GitHub blocked a commit on our branch to the requirements file, {name}, as the local hash we computed didn't match the version on {repo.default_branch}. Make sure you're running safety against the latest code on your default branch.",
+                                fg="red",
+                            )
                             continue
                         else:
                             raise e
 
-                    pr = repo.create_pull(title=pr_prefix + utils.generate_title(pkg, remediation, vulns), body=utils.generate_body(pkg, remediation, vulns, api_key=obj.key), head=new_branch, base=repo.default_branch)
+                    pr = repo.create_pull(
+                        title=pr_prefix + utils.generate_title(pkg, remediation, vulns),
+                        body=utils.generate_body(
+                            pkg, remediation, vulns, api_key=obj.key
+                        ),
+                        head=new_branch,
+                        base=repo.default_branch,
+                    )
                     LOG.debug(f"Created Pull Request to update {pkg}")
 
                     created += 1
@@ -275,20 +365,33 @@ def github_pr(obj: Any, repo: str, token: str, base_url: Optional[str]) -> None:
                             pr.add_to_labels(score_as_label)
 
     if len(pending_updates) > 0:
-        click.secho("The following remediations were not followed: {}".format(', '.join(pending_updates)), fg='red')
+        click.secho(
+            "The following remediations were not followed: {}".format(
+                ", ".join(pending_updates)
+            ),
+            fg="red",
+        )
 
     if created:
-        click.secho(f'Safety successfully created {created} GitHub PR{"s" if created > 1 else ""} for repo {repo_name}')
+        click.secho(
+            f"Safety successfully created {created} GitHub PR{'s' if created > 1 else ''} for repo {repo_name}"
+        )
     else:
-        click.secho('No PRs created; please run the command with debug mode for more information.')
+        click.secho(
+            "No PRs created; please run the command with debug mode for more information."
+        )
 
 
 @click.command()
-@click.option('--repo', help='GitHub standard repo path (eg, my-org/my-project)')
-@click.option('--token', help='GitHub Access Token')
-@click.option('--base-url', help='Optional custom Base URL, if you\'re using GitHub enterprise', default=None)
+@click.option("--repo", help="GitHub standard repo path (eg, my-org/my-project)")
+@click.option("--token", help="GitHub Access Token")
+@click.option(
+    "--base-url",
+    help="Optional custom Base URL, if you're using GitHub enterprise",
+    default=None,
+)
 @click.pass_obj
-@utils.require_files_report # TODO: For now, it can be removed in the future to support env scans.
+@utils.require_files_report  # TODO: For now, it can be removed in the future to support env scans.
 def github_issue(obj: Any, repo: str, token: str, base_url: Optional[str]) -> None:
     """
     Create a GitHub Issue for any vulnerabilities found using PyUp's remediation data.
@@ -301,24 +404,29 @@ def github_issue(obj: Any, repo: str, token: str, base_url: Optional[str]) -> No
         token (str): The GitHub Access Token.
         base_url (Optional[str]): Custom base URL for GitHub Enterprise, if applicable.
     """
-    LOG.info(f'github_issue')
+    LOG.info("github_issue")
 
     if pygithub is None:
-        click.secho("pygithub is not installed. Did you install Safety with GitHub support? Try pip install safety[github]", fg='red')
+        click.secho(
+            "pygithub is not installed. Did you install Safety with GitHub support? Try pip install safety[github]",
+            fg="red",
+        )
         sys.exit(1)
 
     # Load alert configurations from the policy
-    alert = obj.policy.get('alert', {}) or {}
-    security = alert.get('security', {}) or {}
-    config_issue = security.get('github-issue', {}) or {}
+    alert = obj.policy.get("alert", {}) or {}
+    security = alert.get("security", {}) or {}
+    config_issue = security.get("github-issue", {}) or {}
 
-    issue_prefix = config_issue.get('issue-prefix', '[PyUp] ')
-    assignees = config_issue.get('assignees', [])
-    labels = config_issue.get('labels', ['security'])
+    issue_prefix = config_issue.get("issue-prefix", "[PyUp] ")
+    assignees = config_issue.get("assignees", [])
+    labels = config_issue.get("labels", ["security"])
 
-    label_severity = config_issue.get('label-severity', True)
-    ignore_cvss_severity_below = config_issue.get('ignore-cvss-severity-below', 0)
-    ignore_cvss_unknown_severity = config_issue.get('ignore-cvss-unknown-severity', False)
+    label_severity = config_issue.get("label-severity", True)
+    ignore_cvss_severity_below = config_issue.get("ignore-cvss-severity-below", 0)
+    ignore_cvss_unknown_severity = config_issue.get(
+        "ignore-cvss-unknown-severity", False
+    )
 
     # Authenticate with GitHub
     gh = pygithub.Github(token, **({"base_url": base_url} if base_url else {}))
@@ -326,42 +434,61 @@ def github_issue(obj: Any, repo: str, token: str, base_url: Optional[str]) -> No
     repo = gh.get_repo(repo)
 
     # Get all open issues for the repository
-    issues = list(repo.get_issues(state='open', sort='created'))
+    issues = list(repo.get_issues(state="open", sort="created"))
     ISSUE_TITLE_REGEX = re.escape(issue_prefix) + r"Security Vulnerability in (.+)"
-    req_remediations = list(itertools.chain.from_iterable(
-        rem.get('requirements', {}).values() for pkg_name, rem in obj.report['remediations'].items()))
+    req_remediations = list(
+        itertools.chain.from_iterable(
+            rem.get("requirements", {}).values()
+            for pkg_name, rem in obj.report["remediations"].items()
+        )
+    )
 
     created = 0
 
     # Iterate over all requirements files and process each remediation
     for name, contents in obj.requirements_files.items():
-        raw_contents = contents
-        contents = contents.decode('utf-8') # TODO - encoding?
+        contents = contents.decode("utf-8")  # TODO - encoding?
         parsed_req_file = requirements.RequirementFile(name, contents)
 
         for remediation in req_remediations:
-            pkg: str = remediation['requirement']['name']
+            pkg: str = remediation["requirement"]["name"]
             pkg_canonical_name: str = canonicalize_name(pkg)
-            analyzed_spec: str = remediation['requirement']['specifier']
+            analyzed_spec: str = remediation["requirement"]["specifier"]
 
             # Skip remediations without a recommended version
-            if remediation['recommended_version'] is None:
-                LOG.debug(f"The GitHub Issue alerter only currently supports remediations that have a recommended_version: {pkg}")
+            if remediation["recommended_version"] is None:
+                LOG.debug(
+                    f"The GitHub Issue alerter only currently supports remediations that have a recommended_version: {pkg}"
+                )
                 continue
 
             # We have a single remediation that can have multiple vulnerabilities
             # Find all vulnerabilities associated with the remediation
-            vulns = [x for x in obj.report['vulnerabilities'] if x['package_name'] == pkg_canonical_name and x['analyzed_requirement']['specifier'] == analyzed_spec]
+            vulns = [
+                x
+                for x in obj.report["vulnerabilities"]
+                if x["package_name"] == pkg_canonical_name
+                and x["analyzed_requirement"]["specifier"] == analyzed_spec
+            ]
 
             # Skip if all vulnerabilities have unknown severity and the ignore flag is set
-            if ignore_cvss_unknown_severity and all(x['severity'] is None for x in vulns):
-                LOG.debug("All vulnerabilities have unknown severity, and ignore_cvss_unknown_severity is set.")
+            if ignore_cvss_unknown_severity and all(
+                x["severity"] is None for x in vulns
+            ):
+                LOG.debug(
+                    "All vulnerabilities have unknown severity, and ignore_cvss_unknown_severity is set."
+                )
                 continue
 
             highest_base_score = 0
             for vuln in vulns:
-                if vuln['severity'] is not None:
-                    highest_base_score = max(highest_base_score, (vuln['severity'].get('cvssv3', {}) or {}).get('base_score', 10))
+                if vuln["severity"] is not None:
+                    highest_base_score = max(
+                        highest_base_score,
+                        (vuln["severity"].get("cvssv3", {}) or {}).get(
+                            "base_score", 10
+                        ),
+                    )
 
             # Skip if none of the vulnerabilities meet the severity threshold
             if ignore_cvss_severity_below:
@@ -369,23 +496,41 @@ def github_issue(obj: Any, repo: str, token: str, base_url: Optional[str]) -> No
                 for vuln in vulns:
                     # Consider a None severity as a match, since it's controlled by a different flag
                     # If we can't find a base_score but we have severity data, assume it's critical for now.
-                    if vuln['severity'] is None or (vuln['severity'].get('cvssv3', {}) or {}).get('base_score', 10) >= ignore_cvss_severity_below:
+                    if (
+                        vuln["severity"] is None
+                        or (vuln["severity"].get("cvssv3", {}) or {}).get(
+                            "base_score", 10
+                        )
+                        >= ignore_cvss_severity_below
+                    ):
                         at_least_one_match = True
                         break
 
                 if not at_least_one_match:
-                    LOG.debug(f"None of the vulnerabilities found have a score greater than or equal to the ignore_cvss_severity_below of {ignore_cvss_severity_below}")
+                    LOG.debug(
+                        f"None of the vulnerabilities found have a score greater than or equal to the ignore_cvss_severity_below of {ignore_cvss_severity_below}"
+                    )
                     continue
 
             for parsed_req in parsed_req_file.requirements:
-                specs = SpecifierSet('>=0') if parsed_req.specs == SpecifierSet('') else parsed_req.specs
-                if canonicalize_name(parsed_req.name) == pkg_canonical_name and str(specs) == analyzed_spec:
+                specs = (
+                    SpecifierSet(">=0")
+                    if parsed_req.specs == SpecifierSet("")
+                    else parsed_req.specs
+                )
+                if (
+                    canonicalize_name(parsed_req.name) == pkg_canonical_name
+                    and str(specs) == analyzed_spec
+                ):
                     skip = False
                     for issue in issues:
                         match = re.match(ISSUE_TITLE_REGEX, issue.title)
                         if match:
                             group = match.group(1)
-                            if group == f"{pkg}{analyzed_spec}" or group == f"{pkg_canonical_name}{analyzed_spec}":
+                            if (
+                                group == f"{pkg}{analyzed_spec}"
+                                or group == f"{pkg_canonical_name}{analyzed_spec}"
+                            ):
                                 skip = True
                                 break
 
@@ -393,11 +538,18 @@ def github_issue(obj: Any, repo: str, token: str, base_url: Optional[str]) -> No
                     # Skip if an issue already exists for this remediation
                     if skip:
                         LOG.debug(
-                            f"An issue already exists for {pkg}{analyzed_spec} - skipping")
+                            f"An issue already exists for {pkg}{analyzed_spec} - skipping"
+                        )
                         continue
 
                     # Create a new GitHub issue
-                    pr = repo.create_issue(title=issue_prefix + utils.generate_issue_title(pkg, remediation), body=utils.generate_issue_body(pkg, remediation, vulns, api_key=obj.key))
+                    pr = repo.create_issue(
+                        title=issue_prefix
+                        + utils.generate_issue_title(pkg, remediation),
+                        body=utils.generate_issue_body(
+                            pkg, remediation, vulns, api_key=obj.key
+                        ),
+                    )
                     created += 1
                     LOG.debug(f"Created issue to update {pkg}")
 
@@ -414,7 +566,10 @@ def github_issue(obj: Any, repo: str, token: str, base_url: Optional[str]) -> No
                             pr.add_to_labels(score_as_label)
 
     if created:
-        click.secho(f'Safety successfully created {created} new GitHub Issue{"s" if created > 1 else ""} for repo {repo_name}')
+        click.secho(
+            f"Safety successfully created {created} new GitHub Issue{'s' if created > 1 else ''} for repo {repo_name}"
+        )
     else:
-        click.secho('No issues created; please run the command with debug mode for more information.')
-
+        click.secho(
+            "No issues created; please run the command with debug mode for more information."
+        )

--- a/safety/alerts/utils.py
+++ b/safety/alerts/utils.py
@@ -1,3 +1,4 @@
+# type: ignore
 import hashlib
 import os
 import sys
@@ -14,7 +15,11 @@ import click
 # It's fine if our functions fail, but don't let this top level
 # import error out.
 from safety.models import is_pinned_requirement
-from safety.output_utils import get_unpinned_hint, get_specifier_range_info, get_fix_hint_for_unpinned
+from safety.output_utils import (
+    get_unpinned_hint,
+    get_specifier_range_info,
+    get_fix_hint_for_unpinned,
+)
 
 try:
     import jinja2
@@ -22,6 +27,7 @@ except ImportError:
     jinja2 = None
 
 import requests
+from safety.meta import get_meta_http_headers
 
 
 def highest_base_score(vulns: List[Dict[str, Any]]) -> float:
@@ -36,8 +42,11 @@ def highest_base_score(vulns: List[Dict[str, Any]]) -> float:
     """
     highest_base_score = 0
     for vuln in vulns:
-        if vuln['severity'] is not None:
-            highest_base_score = max(highest_base_score, (vuln['severity'].get('cvssv3', {}) or {}).get('base_score', 10))
+        if vuln["severity"] is not None:
+            highest_base_score = max(
+                highest_base_score,
+                (vuln["severity"].get("cvssv3", {}) or {}).get("base_score", 10),
+            )
 
     return highest_base_score
 
@@ -80,18 +89,24 @@ def get_hint(remediation: Dict[str, Any]) -> str:
     Returns:
         str: The generated hint.
     """
-    pinned = is_pinned_requirement(SpecifierSet(remediation['requirement']['specifier']))
-    hint = ''
+    pinned = is_pinned_requirement(
+        SpecifierSet(remediation["requirement"]["specifier"])
+    )
+    hint = ""
 
     if not pinned:
         fix_hint = get_fix_hint_for_unpinned(remediation)
-        hint = f"{fix_hint}\n\n{get_unpinned_hint(remediation['requirement']['name'])} " \
-               f"{get_specifier_range_info(style=False)}"
+        hint = (
+            f"{fix_hint}\n\n{get_unpinned_hint(remediation['requirement']['name'])} "
+            f"{get_specifier_range_info(style=False)}"
+        )
 
     return hint
 
 
-def generate_title(pkg: str, remediation: Dict[str, Any], vulns: List[Dict[str, Any]]) -> str:
+def generate_title(
+    pkg: str, remediation: Dict[str, Any], vulns: List[Dict[str, Any]]
+) -> str:
     """
     Generates a title for a pull request or issue.
 
@@ -104,11 +119,17 @@ def generate_title(pkg: str, remediation: Dict[str, Any], vulns: List[Dict[str, 
         str: The generated title.
     """
     suffix = "y" if len(vulns) == 1 else "ies"
-    from_dependency = remediation['version'] if remediation['version'] else remediation['requirement']['specifier']
+    from_dependency = (
+        remediation["version"]
+        if remediation["version"]
+        else remediation["requirement"]["specifier"]
+    )
     return f"Update {pkg} from {from_dependency} to {remediation['recommended_version']} to fix {len(vulns)} vulnerabilit{suffix}"
 
 
-def generate_body(pkg: str, remediation: Dict[str, Any], vulns: List[Dict[str, Any]], *, api_key: str) -> Optional[str]:
+def generate_body(
+    pkg: str, remediation: Dict[str, Any], vulns: List[Dict[str, Any]], *, api_key: str
+) -> Optional[str]:
     """
     Generates the body content for a pull request.
 
@@ -121,17 +142,29 @@ def generate_body(pkg: str, remediation: Dict[str, Any], vulns: List[Dict[str, A
     Returns:
         str: The generated body content.
     """
-    changelog = fetch_changelog(pkg, remediation['version'], remediation['recommended_version'],
-                                api_key=api_key, from_spec=remediation.get('requirement', {}).get('specifier', None))
+    changelog = fetch_changelog(
+        pkg,
+        remediation["version"],
+        remediation["recommended_version"],
+        api_key=api_key,
+        from_spec=remediation.get("requirement", {}).get("specifier", None),
+    )
 
-    p = Path(__file__).parent / 'templates'
-    env = jinja2.Environment(loader=jinja2.FileSystemLoader(Path(p)))
-    template = env.get_template('pr.jinja2')
+    p = Path(__file__).parent / "templates"
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(Path(p)))  # type: ignore
+    template = env.get_template("pr.jinja2")
 
     overall_impact = cvss3_score_to_label(highest_base_score(vulns))
 
-    context = {"pkg": pkg, "remediation": remediation, "vulns": vulns, "changelog": changelog,
-               "overall_impact": overall_impact, "summary_changelog": False, "hint": get_hint(remediation)}
+    context = {
+        "pkg": pkg,
+        "remediation": remediation,
+        "vulns": vulns,
+        "changelog": changelog,
+        "overall_impact": overall_impact,
+        "summary_changelog": False,
+        "hint": get_hint(remediation),
+    }
 
     result = template.render(context)
 
@@ -144,7 +177,9 @@ def generate_body(pkg: str, remediation: Dict[str, Any], vulns: List[Dict[str, A
     return template.render(context)
 
 
-def generate_issue_body(pkg: str, remediation: Dict[str, Any], vulns: List[Dict[str, Any]], *, api_key: str) -> Optional[str]:
+def generate_issue_body(
+    pkg: str, remediation: Dict[str, Any], vulns: List[Dict[str, Any]], *, api_key: str
+) -> Optional[str]:
     """
     Generates the body content for an issue.
 
@@ -157,17 +192,29 @@ def generate_issue_body(pkg: str, remediation: Dict[str, Any], vulns: List[Dict[
     Returns:
         str: The generated body content.
     """
-    changelog = fetch_changelog(pkg, remediation['version'], remediation['recommended_version'],
-                                api_key=api_key, from_spec=remediation.get('requirement', {}).get('specifier', None))
+    changelog = fetch_changelog(
+        pkg,
+        remediation["version"],
+        remediation["recommended_version"],
+        api_key=api_key,
+        from_spec=remediation.get("requirement", {}).get("specifier", None),
+    )
 
-    p = Path(__file__).parent / 'templates'
-    env = jinja2.Environment(loader=jinja2.FileSystemLoader(Path(p)))
-    template = env.get_template('issue.jinja2')
+    p = Path(__file__).parent / "templates"
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(Path(p)))  # type: ignore
+    template = env.get_template("issue.jinja2")
 
     overall_impact = cvss3_score_to_label(highest_base_score(vulns))
 
-    context = {"pkg": pkg, "remediation": remediation, "vulns": vulns, "changelog": changelog,
-               "overall_impact": overall_impact, "summary_changelog": False, "hint": get_hint(remediation)}
+    context = {
+        "pkg": pkg,
+        "remediation": remediation,
+        "vulns": vulns,
+        "changelog": changelog,
+        "overall_impact": overall_impact,
+        "summary_changelog": False,
+        "hint": get_hint(remediation),
+    }
 
     result = template.render(context)
 
@@ -191,9 +238,15 @@ def generate_commit_message(pkg: str, remediation: Dict[str, Any]) -> str:
     Returns:
         str: The generated commit message.
     """
-    from_dependency = remediation['version'] if remediation['version'] else remediation['requirement']['specifier']
+    from_dependency = (
+        remediation["version"]
+        if remediation["version"]
+        else remediation["requirement"]["specifier"]
+    )
 
-    return f"Update {pkg} from {from_dependency} to {remediation['recommended_version']}"
+    return (
+        f"Update {pkg} from {from_dependency} to {remediation['recommended_version']}"
+    )
 
 
 def git_sha1(raw_contents: bytes) -> str:
@@ -206,10 +259,19 @@ def git_sha1(raw_contents: bytes) -> str:
     Returns:
         str: The SHA-1 hash.
     """
-    return hashlib.sha1(b"blob " + str(len(raw_contents)).encode('ascii') + b"\0" + raw_contents).hexdigest()
+    return hashlib.sha1(
+        b"blob " + str(len(raw_contents)).encode("ascii") + b"\0" + raw_contents
+    ).hexdigest()
 
 
-def fetch_changelog(package: str, from_version: Optional[str], to_version: str, *, api_key: str, from_spec: Optional[str] = None) -> Dict[str, Any]:
+def fetch_changelog(
+    package: str,
+    from_version: Optional[str],
+    to_version: str,
+    *,
+    api_key: str,
+    from_spec: Optional[str] = None,
+) -> Dict[str, Any]:
     """
     Fetches the changelog for a package from a specified version to another version.
 
@@ -223,35 +285,44 @@ def fetch_changelog(package: str, from_version: Optional[str], to_version: str, 
     Returns:
         Dict[str, Any]: The fetched changelog data.
     """
-    to_version = parse_version(to_version)
+    to_version_parsed = parse_version(to_version)
 
     if from_version:
-        from_version = parse_version(from_version)
+        from_version_parsed = parse_version(from_version)
     else:
+        from_version_parsed = None
         from_spec = SpecifierSet(from_spec)
 
     changelog = {}
 
+    headers = {"X-Api-Key": api_key}
+    headers.update(get_meta_http_headers())
+
     r = requests.get(
-        "https://pyup.io/api/v1/changelogs/{}/".format(package),
-        headers={"X-Api-Key": api_key}
+        "https://pyup.io/api/v1/changelogs/{}/".format(package), headers=headers
     )
 
     if r.status_code == 200:
         data = r.json()
         if data:
             # sort the changelog by release
-            sorted_log = sorted(data.items(), key=lambda v: parse_version(v[0]), reverse=True)
+            sorted_log = sorted(
+                data.items(), key=lambda v: parse_version(v[0]), reverse=True
+            )
 
             # go over each release and add it to the log if it's within the "upgrade
             # range" e.g. update from 1.2 to 1.3 includes a changelog for 1.2.1 but
             # not for 0.4.
             for version, log in sorted_log:
                 parsed_version = parse_version(version)
-                version_check = from_version and (parsed_version > from_version)
-                spec_check = from_spec and isinstance(from_spec, SpecifierSet) and from_spec.contains(parsed_version)
+                version_check = from_version and (parsed_version > from_version_parsed)
+                spec_check = (
+                    from_spec
+                    and isinstance(from_spec, SpecifierSet)
+                    and from_spec.contains(parsed_version)
+                )
 
-                if version_check or spec_check and parsed_version <= to_version:
+                if version_check or spec_check and parsed_version <= to_version_parsed:
                     changelog[version] = log
 
     return changelog
@@ -268,13 +339,13 @@ def cvss3_score_to_label(score: float) -> Optional[str]:
         Optional[str]: The severity label.
     """
     if 0.1 <= score <= 3.9:
-        return 'low'
+        return "low"
     elif 4.0 <= score <= 6.9:
-        return 'medium'
+        return "medium"
     elif 7.0 <= score <= 8.9:
-        return 'high'
+        return "high"
     elif 9.0 <= score <= 10.0:
-        return 'critical'
+        return "critical"
 
     return None
 
@@ -293,21 +364,30 @@ def require_files_report(func):
         Returns:
             Any: The result of the decorated function.
         """
-        if obj.report['report_meta']['scan_target'] != "files":
-            click.secho("This report was generated against an environment, but this alert command requires "
-                        "a scan report that was generated against a file. To learn more about the "
-                        "`safety alert` command visit https://docs.pyup.io/docs/safety-2-alerts", fg='red')
+        if obj.report["report_meta"]["scan_target"] != "files":
+            click.secho(
+                "This report was generated against an environment, but this alert command requires "
+                "a scan report that was generated against a file. To learn more about the "
+                "`safety alert` command visit https://docs.pyup.io/docs/safety-2-alerts",
+                fg="red",
+            )
             sys.exit(1)
 
-        files = obj.report['report_meta']['scanned']
+        files = obj.report["report_meta"]["scanned"]
         obj.requirements_files = {}
         for f in files:
             if not os.path.exists(f):
                 cwd = os.getcwd()
-                click.secho("A requirements file scanned in the report, {}, does not exist (looking in {}).".format(f, cwd), fg='red')
+                click.secho(
+                    "A requirements file scanned in the report, {}, does not exist (looking in {}).".format(
+                        f, cwd
+                    ),
+                    fg="red",
+                )
                 sys.exit(1)
 
             obj.requirements_files[f] = open(f, "rb").read()
 
         return func(obj, *args, **kwargs)
+
     return inner

--- a/safety/meta.py
+++ b/safety/meta.py
@@ -1,6 +1,7 @@
 from importlib.metadata import PackageNotFoundError, version
 import logging
 import os
+import platform
 from typing import Dict, Optional
 
 
@@ -37,6 +38,33 @@ def get_identifier() -> str:
     return SourceType.SAFETY_CLI_PYPI.value
 
 
+def get_user_agent() -> str:
+    """
+    Get the user agent string for HTTP requests.
+
+    Returns:
+      str: The user agent string in the format: safety-cli/{version} ({os} {arch}; Python/{python_version})
+    """
+    safety_version = get_version() or "unknown"
+    os_name = platform.system()
+
+    # Get architecture
+    machine = platform.machine()
+    # Normalize architecture names
+    if machine in ("x86_64", "AMD64"):
+        arch = "x86_64"
+    elif machine in ("arm64", "aarch64"):
+        arch = "arm_64"
+    elif machine == "i386":
+        arch = "x86"
+    else:
+        arch = machine or "unknown"
+
+    python_version = platform.python_version()
+
+    return f"safety-cli/{safety_version} ({os_name} {arch}; Python/{python_version})"
+
+
 def get_meta_http_headers() -> Dict[str, str]:
     """
     Get the metadata headers for the client.
@@ -52,4 +80,5 @@ def get_meta_http_headers() -> Dict[str, str]:
     return {
         f"{namespace}-Client-Version": get_version() or "",
         f"{namespace}-Client-Id": get_identifier(),
+        "User-Agent": get_user_agent(),
     }

--- a/safety/safety.py
+++ b/safety/safety.py
@@ -51,6 +51,7 @@ from .errors import (
     ServerError,
     MalformedDatabase,
 )
+from .meta import get_meta_http_headers
 from .models import (
     Vulnerability,
     CVE,
@@ -241,6 +242,7 @@ def fetch_database_url(
         Dict[str, Any]: The fetched database.
     """
     headers = {"schema-version": JSON_SCHEMA_VERSION, "ecosystem": ecosystem.value}
+    headers.update(get_meta_http_headers())
 
     if cached and from_cache:
         cached_data = get_from_cache(db_name=db_name, cache_valid_seconds=cached)
@@ -301,7 +303,8 @@ def fetch_policy(session: requests.Session) -> Dict[str, Any]:
 
     try:
         LOG.debug("Getting policy")
-        r = session.get(url=url, timeout=REQUEST_TIMEOUT)
+        headers = get_meta_http_headers()
+        r = session.get(url=url, timeout=REQUEST_TIMEOUT, headers=headers)
         LOG.debug(r.text)
         return r.json()
     except Exception:
@@ -1791,6 +1794,7 @@ def get_announcements(
 
     request_kwargs[data_keyword] = data
     request_kwargs["url"] = url
+    request_kwargs["headers"] = get_meta_http_headers()
 
     LOG.debug(f"Telemetry data sent: {data}")
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,141 @@
+import unittest
+from unittest.mock import patch
+
+from safety.meta import get_user_agent, get_meta_http_headers
+
+
+class TestMeta(unittest.TestCase):
+    """Test cases for the meta module."""
+
+    def test_get_user_agent_format(self):
+        """Test that get_user_agent returns the expected format."""
+        user_agent = get_user_agent()
+
+        # Check that it starts with "safety-cli/"
+        self.assertTrue(user_agent.startswith("safety-cli/"))
+
+        # Check that it contains the OS and architecture in parentheses
+        self.assertIn("(", user_agent)
+        self.assertIn(")", user_agent)
+
+        # Check that it contains Python version
+        self.assertIn("Python/", user_agent)
+
+    @patch("safety.meta.platform.system")
+    @patch("safety.meta.platform.machine")
+    @patch("safety.meta.platform.python_version")
+    @patch("safety.meta.get_version")
+    def test_get_user_agent_values(
+        self, mock_get_version, mock_python_version, mock_machine, mock_system
+    ):
+        """Test get_user_agent with specific platform values."""
+        # Test Linux x86_64
+        mock_get_version.return_value = "3.0.1"
+        mock_system.return_value = "Linux"
+        mock_machine.return_value = "x86_64"
+        mock_python_version.return_value = "3.10.0"
+
+        user_agent = get_user_agent()
+        self.assertEqual(user_agent, "safety-cli/3.0.1 (Linux x86_64; Python/3.10.0)")
+
+        # Test macOS (Darwin) arm64
+        mock_system.return_value = "Darwin"
+        mock_machine.return_value = "arm64"
+
+        user_agent = get_user_agent()
+        self.assertEqual(user_agent, "safety-cli/3.0.1 (Darwin arm_64; Python/3.10.0)")
+
+        # Test Windows AMD64
+        mock_system.return_value = "Windows"
+        mock_machine.return_value = "AMD64"
+
+        user_agent = get_user_agent()
+        self.assertEqual(user_agent, "safety-cli/3.0.1 (Windows x86_64; Python/3.10.0)")
+
+        # Test unknown architecture
+        mock_machine.return_value = "unknown_arch"
+
+        user_agent = get_user_agent()
+        self.assertEqual(
+            user_agent, "safety-cli/3.0.1 (Windows unknown_arch; Python/3.10.0)"
+        )
+
+        # Test with no version
+        mock_get_version.return_value = None
+
+        user_agent = get_user_agent()
+        self.assertEqual(
+            user_agent, "safety-cli/unknown (Windows unknown_arch; Python/3.10.0)"
+        )
+
+    @patch("safety.meta.platform.machine")
+    def test_get_user_agent_architecture_normalization(self, mock_machine):
+        """Test that architecture names are properly normalized."""
+        test_cases = [
+            ("x86_64", "x86_64"),
+            ("AMD64", "x86_64"),
+            ("arm64", "arm_64"),
+            ("aarch64", "arm_64"),
+            ("i386", "x86"),
+            ("custom_arch", "custom_arch"),
+            ("", "unknown"),
+            (None, "unknown"),
+        ]
+
+        for machine_value, expected_arch in test_cases:
+            mock_machine.return_value = machine_value
+            user_agent = get_user_agent()
+            # Extract the architecture from the user agent string
+            # Format: safety-cli/version (OS arch; Python/version)
+            parts = user_agent.split(" ")
+            arch = parts[2].rstrip(";")
+            self.assertEqual(
+                arch,
+                expected_arch,
+                f"Expected {expected_arch} for machine={machine_value}",
+            )
+
+    @patch("safety.meta.get_version")
+    @patch("safety.meta.get_identifier")
+    def test_get_meta_http_headers_includes_user_agent(
+        self, mock_get_identifier, mock_get_version
+    ):
+        """Test that get_meta_http_headers includes User-Agent header."""
+        mock_get_version.return_value = "3.0.1"
+        mock_get_identifier.return_value = "safety_cli_pypi"
+
+        headers = get_meta_http_headers()
+
+        # Check that User-Agent is included
+        self.assertIn("User-Agent", headers)
+
+        # Check that it starts with "safety-cli/"
+        self.assertTrue(headers["User-Agent"].startswith("safety-cli/"))
+
+        # Check other headers are still present
+        self.assertIn("Safetycli-Client-Version", headers)
+        self.assertIn("Safetycli-Client-Id", headers)
+        self.assertEqual(headers["Safetycli-Client-Version"], "3.0.1")
+        self.assertEqual(headers["Safetycli-Client-Id"], "safety_cli_pypi")
+
+    def test_get_meta_http_headers_complete(self):
+        """Test that get_meta_http_headers returns all expected headers."""
+        headers = get_meta_http_headers()
+
+        # All required headers should be present
+        required_headers = [
+            "User-Agent",
+            "Safetycli-Client-Version",
+            "Safetycli-Client-Id",
+        ]
+        for header in required_headers:
+            self.assertIn(header, headers, f"Missing required header: {header}")
+
+        # Verify User-Agent format
+        user_agent = headers["User-Agent"]
+        self.assertTrue(user_agent.startswith("safety-cli/"))
+        self.assertIn("Python/", user_agent)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_user_agent_integration.py
+++ b/tests/test_user_agent_integration.py
@@ -1,0 +1,229 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from safety.meta import get_meta_http_headers
+from safety.safety import fetch_database_url, fetch_policy, get_announcements
+from safety.alerts.utils import fetch_changelog
+from safety.alerts.requirements import Requirement
+from safety.auth.utils import SafetyAuthSession
+
+
+class TestUserAgentIntegration(unittest.TestCase):
+    """Integration tests to verify user-agent is properly set in all HTTP requests."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.expected_headers = get_meta_http_headers()
+        self.user_agent = self.expected_headers["User-Agent"]
+
+    @patch("safety.safety.requests.Session")
+    def test_fetch_database_url_includes_user_agent(self, mock_session_class):
+        """Test that fetch_database_url includes user-agent in headers."""
+        # Setup mock
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"meta": {"schema_version": "2.0"}}
+        mock_session.get.return_value = mock_response
+
+        # Call function
+        from safety.constants import JSON_SCHEMA_VERSION
+        from safety_schemas.models import Ecosystem
+
+        fetch_database_url(
+            session=mock_session,
+            mirror="https://api.safety.test/",
+            db_name="insecure.json",
+            cached=0,
+            telemetry=False,
+            ecosystem=Ecosystem.PYTHON,
+            from_cache=False,
+        )
+
+        # Verify headers were passed correctly
+        mock_session.get.assert_called_once()
+        call_args = mock_session.get.call_args
+        headers = call_args[1]["headers"]
+
+        # Check that user-agent is included
+        self.assertIn("User-Agent", headers)
+        self.assertTrue(headers["User-Agent"].startswith("safety-cli/"))
+
+        # Check other custom headers
+        self.assertIn("Safetycli-Client-Version", headers)
+        self.assertIn("Safetycli-Client-Id", headers)
+        self.assertEqual(headers["schema-version"], JSON_SCHEMA_VERSION)
+        self.assertEqual(headers["ecosystem"], "python")
+
+    @patch("safety.safety.requests.Session")
+    def test_fetch_policy_includes_user_agent(self, mock_session_class):
+        """Test that fetch_policy includes user-agent in headers."""
+        # Setup mock
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "safety_policy": "",
+            "audit_and_monitor": False,
+        }
+        mock_session.get.return_value = mock_response
+
+        # Call function
+        fetch_policy(session=mock_session)
+
+        # Verify headers were passed correctly
+        mock_session.get.assert_called_once()
+        call_args = mock_session.get.call_args
+        headers = call_args[1]["headers"]
+
+        # Check that user-agent is included
+        self.assertIn("User-Agent", headers)
+        self.assertTrue(headers["User-Agent"].startswith("safety-cli/"))
+
+    @patch("safety.safety.requests.Session")
+    def test_get_announcements_includes_user_agent(self, mock_session_class):
+        """Test that get_announcements includes user-agent in headers."""
+        # Setup mock
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"announcements": []}
+
+        # Mock the method to return our response
+        mock_session.post = MagicMock(return_value=mock_response)
+
+        # Call function
+        get_announcements(session=mock_session, telemetry=False)
+
+        # Verify headers were passed correctly
+        mock_session.post.assert_called_once()
+        call_args = mock_session.post.call_args
+        headers = call_args[1]["headers"]
+
+        # Check that user-agent is included
+        self.assertIn("User-Agent", headers)
+        self.assertTrue(headers["User-Agent"].startswith("safety-cli/"))
+
+    @patch("safety.alerts.utils.requests.get")
+    def test_fetch_changelog_includes_user_agent(self, mock_get):
+        """Test that fetch_changelog includes user-agent in headers."""
+        # Setup mock
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {}
+        mock_get.return_value = mock_response
+
+        # Call function
+        fetch_changelog(
+            package="test-package",
+            from_version="1.0.0",
+            to_version="2.0.0",
+            api_key="test-key",
+        )
+
+        # Verify headers were passed correctly
+        mock_get.assert_called_once()
+        call_args = mock_get.call_args
+        headers = call_args[1]["headers"]
+
+        # Check that user-agent is included
+        self.assertIn("User-Agent", headers)
+        self.assertTrue(headers["User-Agent"].startswith("safety-cli/"))
+
+        # Check API key is included
+        self.assertEqual(headers["X-Api-Key"], "test-key")
+
+    @patch("safety.alerts.requirements.requests.get")
+    def test_requirement_get_hashes_includes_user_agent(self, mock_get):
+        """Test that Requirement.get_hashes includes user-agent in headers."""
+        # Setup mock
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"urls": []}
+        mock_get.return_value = mock_response
+
+        # Create requirement instance
+        from packaging.specifiers import SpecifierSet
+
+        req = Requirement(
+            name="TestPackage",
+            specs=SpecifierSet("==1.0.0"),
+            line="TestPackage==1.0.0",
+            lineno=1,
+            extras=[],
+            file_type="requirements.txt",
+        )
+
+        # Call method
+        req.get_hashes("1.0.0")
+
+        # Verify headers were passed correctly
+        mock_get.assert_called_once()
+        call_args = mock_get.call_args
+        headers = call_args[1]["headers"]
+
+        # Check that user-agent is included
+        self.assertIn("User-Agent", headers)
+        self.assertTrue(headers["User-Agent"].startswith("safety-cli/"))
+
+    def test_safety_auth_session_includes_user_agent(self):
+        """Test that SafetyAuthSession includes user-agent in headers."""
+        # Create session
+        session = SafetyAuthSession()
+
+        # Test with API key
+        session.api_key = "test-key"  # type: ignore
+
+        # Mock the parent class request method
+        with patch.object(
+            session.__class__.__bases__[0], "request"
+        ) as mock_super_request:
+            mock_response = MagicMock()
+            mock_super_request.return_value = mock_response
+
+            # Make a request
+            session.request("GET", "https://api.test.com/endpoint")
+
+            # Verify headers were passed correctly
+            mock_super_request.assert_called_once()
+            call_args = mock_super_request.call_args
+            headers = call_args[1]["headers"]
+
+            # Check that user-agent is included
+            self.assertIn("User-Agent", headers)
+            self.assertTrue(headers["User-Agent"].startswith("safety-cli/"))
+
+            # Check API key is included
+            self.assertEqual(headers["X-Api-Key"], "test-key")
+
+    @patch("safety.events.handlers.common.httpx.AsyncClient")
+    def test_events_handler_includes_user_agent(self, mock_client_class):
+        """Test that event handler includes user-agent in headers."""
+        from safety.events.handlers.common import SecurityEventsHandler
+
+        # Create mock client
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        # Setup async mock
+        async def mock_post(*args, **kwargs):
+            return mock_response
+
+        mock_client.post = mock_post
+
+        # Create handler
+        handler = SecurityEventsHandler(
+            api_endpoint="https://events.safety.test/", api_key="test-key"
+        )
+
+        # Set the mock client
+        handler.http_client = mock_client
+
+        # Verify that headers would include user-agent
+        # This is already handled in the flush method which calls get_meta_http_headers()
+        headers = get_meta_http_headers()
+        self.assertIn("User-Agent", headers)
+        self.assertTrue(headers["User-Agent"].startswith("safety-cli/"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
All network requests from the Safety CLI now include a standardized user-agent header in the format: safety-cli/{version} ({os} {arch}; Python/{python_version}). This change enables Safety to distinguish requests coming from the CLI versus other sources when accessing the Safety Vulnerability Database (safety-db), providing better visibility into how the database is being consumed. The user-agent is centrally managed through the get_meta_http_headers() function to ensure consistency across all HTTP clients (requests and httpx).

## Description

<!-- Briefly describe the purpose of this pull request. What changes are introduced, and why? -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## Related Issues

<!-- List any related issues or reference other PRs, if applicable. Example: Fixes #123, Closes #456 -->

## Testing

- [ ] Tests added or updated
- [ ] No tests required

<!-- Briefly describe the testing that was done. Include steps to manually test or reference automated tests. -->

## Checklist

- [ ] Code is well-documented
- [ ] Changelog is updated (if needed)
- [ ] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes

<!-- Any additional notes or comments to help the reviewer. -->
