### PR TITLE
fix: restore missing codebase name prompt in scan command

### DIFF
--- a/safety/codebase/command.py
+++ b/safety/codebase/command.py
@@ -127,7 +127,9 @@ def init(
     org_slug = launch_auth_if_needed(ctx, console)
 
     if not org_slug:
-        raise SafetyError("Organization not found")
+        raise SafetyError(
+            "Organization not found, please run 'safety auth status' or 'safety auth login'"
+        )
 
     should_enable_firewall = not skip_firewall_setup and ctx.obj.firewall_enabled
 

--- a/safety/init/main.py
+++ b/safety/init/main.py
@@ -122,6 +122,7 @@ def verify_project(
     git_origin: Optional[str],
     create_if_missing: bool = True,
     link_behavior: Literal["always", "prompt", "never"] = "prompt",
+    prompt_for_name: bool = False,
 ) -> Tuple[bool, Optional[str]]:
     """
     Verify the project, linking it if necessary and saving the verified project information.
@@ -149,6 +150,7 @@ def verify_project(
 
     # Track if we need to ask for project ID (when user declines linking)
     ask_for_project_id = False
+    asked_codebase_asked_before = False
 
     while True:
         result = check_project(
@@ -172,9 +174,15 @@ def verify_project(
                 return (False, "not_found")
             # Project will be created - continue to verification
             project_status = (True, "created")
+
+            if prompt_for_name and not asked_codebase_asked_before:
+                asked_codebase_asked_before = True
+                ask_for_project_id = True
+                continue
         else:
             # Project exists - handle based on link_behavior
             if link_behavior == "never":
+                unverified_project.id = project.get("slug")
                 return (True, "found")
             elif link_behavior == "always":
                 project_status = (True, "linked")

--- a/safety/scan/decorators.py
+++ b/safety/scan/decorators.py
@@ -91,6 +91,7 @@ def scan_project_command_init(func):
                 unverified_project,
                 origin,
                 link_behavior=link_behavior,
+                prompt_for_name=True,
             )
         else:
             ctx.obj.project = ProjectModel(


### PR DESCRIPTION
The scan command previously prompted users to provide a codebase name when scanning a project that didn't exist in an interactive environment. This functionality was accidentally removed during a refactor of the codebase init command. This fix restores the prompt behavior by adding a prompt_for_name parameter to the verify_project function and ensuring it's enabled when called from the scan command, maintaining the expected user experience for new codebase creation.

