### PR TITLE
Fix/kaleb coberly/import rich utils

### DIFF
--- a/safety/cli.py
+++ b/safety/cli.py
@@ -28,7 +28,6 @@ from safety_schemas.models import (
     Stage,
     VulnerabilitySeverityLabels,
 )
-from typer import rich_utils
 
 from safety.alerts import alert
 from safety.auth import auth_options, proxy_options

--- a/safety/cli.py
+++ b/safety/cli.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import click
 import requests
 import typer
+import typer.rich_utils
 from packaging import version as packaging_version
 from packaging.version import InvalidVersion
 from safety_schemas.config.schemas.v3_0 import main as v3_0
@@ -1248,7 +1249,7 @@ def configure(
 
 
 cli_app = typer.Typer(rich_markup_mode="rich", cls=SafetyCLISubGroup)
-rich_utils.STYLE_HELPTEXT = ""
+typer.rich_utils.STYLE_HELPTEXT = ""
 
 
 def print_check_updates_header(console):

--- a/safety/cli.py
+++ b/safety/cli.py
@@ -27,6 +27,7 @@ from safety_schemas.models import (
     Stage,
     VulnerabilitySeverityLabels,
 )
+from typer import rich_utils
 
 from safety.alerts import alert
 from safety.auth import auth_options, proxy_options
@@ -1247,7 +1248,7 @@ def configure(
 
 
 cli_app = typer.Typer(rich_markup_mode="rich", cls=SafetyCLISubGroup)
-typer.rich_utils.STYLE_HELPTEXT = ""
+rich_utils.STYLE_HELPTEXT = ""
 
 
 def print_check_updates_header(console):


### PR DESCRIPTION
## Description

Replaces https://github.com/pyupio/safety/pull/779 with corrected commit-message convention.

Addresses https://github.com/pyupio/safety/issues/778, where accessing `typer.rich_utils` as an attribute is no longer valid for `typer>=0.17.0` because it now lazily imports `rich_utils`: https://github.com/fastapi/typer/discussions/1285

## Type of Change

- [ x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## Related Issues

Fixes https://github.com/pyupio/safety/issues/778
Addresses https://github.com/fastapi/typer/discussions/1285

## Testing

- [ ] Tests added or updated
- [? ] No tests required

```
(my_safety_env) My-MacBook-Pro:safety KalebCoberly$ pip install -e .
...
Installing collected packages: safety
  Attempting uninstall: safety
    Found existing installation: safety 3.6.0
    Uninstalling safety-3.6.0:
      Successfully uninstalled safety-3.6.0
Successfully installed safety-3.6.1b0
(my_safety_env) My-MacBook-Pro:safety KalebCoberly$
(my_safety_env) My-MacBook-Pro:safety KalebCoberly$ cd ../my_repo_to_run_safety_in
(my_safety_env) My-MacBook-Pro:safety KalebCoberly$
(my_safety_env) My-MacBook-Pro:safety KalebCoberly$ safety --key ***** scan
...
0 security issues found, 0 fixes suggested.
0 fixes suggested, resolving 0 vulnerabilities.
```

## Checklist

- [ x] Code is well-documented
- [ ?] Changelog is updated (if needed)
- [x ] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes

I've left the changelog and version as is because I'm not sure how you'd like to update and handle releasing, and I noticed previous commits to main without accompanying changes. Happy to update those, though.
