### PR TITLE
Restrict typer version to <0.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "safety-schemas==0.0.14",
   # TODO: To be removed after migrate away from pkg_resources
   "setuptools>=65.5.1",
-  "typer>=0.16.0",
+  "typer>=0.16.0,<0.17",
   "typing-extensions>=4.7.1",
   "nltk>=3.9",
   "tomli; python_version < '3.11'",


### PR DESCRIPTION
With typer version 0.17.3, Safety cli fails:
```
uv run safety check
Traceback (most recent call last):
  File "/home/runner/work/coordinate-projector/coordinate-projector/.venv/bin/safety", line 4, in <module>
    from safety.cli import cli
  File "/home/runner/work/coordinate-projector/coordinate-projector/.venv/lib/python3.11/site-packages/safety/cli.py", line 1250, in <module>
    typer.rich_utils.STYLE_HELPTEXT = ""
    ^^^^^^^^^^^^^^^^
AttributeError: module 'typer' has no attribute 'rich_utils'
Error: Process completed with exit code 1.
```

## Description

<!-- Briefly describe the purpose of this pull request. What changes are introduced, and why? -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## Related Issues

<!-- List any related issues or reference other PRs, if applicable. Example: Fixes #123, Closes #456 -->

## Testing

- [ ] Tests added or updated
- [x] No tests required

<!-- Briefly describe the testing that was done. Include steps to manually test or reference automated tests. -->

## Checklist

- [ ] Code is well-documented
- [ ] Changelog is updated (if needed)
- [ ] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes

Probably need to update any lock files.
