### PR TITLE
fix: run audit on all commands that affect the state of dependencies

### DIFF
--- a/safety/tool/base.py
+++ b/safety/tool/base.py
@@ -6,10 +6,9 @@ from pathlib import Path
 import shutil
 import subprocess
 import time
-from typing import Any, Dict, List, Optional
-from filelock import FileLock
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from dataclasses import dataclass
 import typer
-from safety.constants import USER_CONFIG_DIR
 from safety.events.utils import emit_tool_command_executed
 from safety.models import ToolResult
 from safety.tool.constants import (
@@ -19,7 +18,7 @@ from safety.tool.constants import (
 from safety.tool.typosquatting import TyposquattingProtection
 
 from .environment_diff import EnvironmentDiffTracker
-from .intents import CommandToolIntention, ToolIntentionType
+from .intents import CommandToolIntention, ToolIntentionType, Dependency
 from .resolver import get_unwrapped_command
 
 from safety_schemas.models.events.types import ToolType
@@ -61,8 +60,6 @@ class BaseCommand(ABC):
         self._command_alias_used = command_alias_used
 
         self._tool_type = self.get_tool_type()
-        self._lock_path = USER_CONFIG_DIR / self.get_lock_path()
-        self._filelock = FileLock(self._lock_path, 10)
         self.__typosquatting_protection = TyposquattingProtection(
             MOST_FREQUENTLY_DOWNLOADED_PYPI_PACKAGES
         )
@@ -93,17 +90,6 @@ class BaseCommand(ABC):
         pass
 
     @abstractmethod
-    def get_lock_path(self) -> str:
-        """
-        Get the lock path for this command type.
-        Must be implemented by subclasses.
-
-        Returns:
-            str: Path to the lock file
-        """
-        pass
-
-    @abstractmethod
     def get_diff_tracker(self) -> EnvironmentDiffTracker:
         """
         Get the diff tracker instance for this command type.
@@ -122,12 +108,10 @@ class BaseCommand(ABC):
         Returns:
             bool: True if state changes should be tracked
         """
-        # Default implementation checks for common installation commands
-        command_str = " ".join(self._args).lower()
-        return any(
-            cmd in command_str
-            for cmd in ["install", "uninstall", "add", "remove", "sync"]
-        )
+        if self._intention:
+            return self._intention.modifies_packages()
+
+        return False
 
     def get_package_list_command(self) -> List[str]:
         """
@@ -238,12 +222,19 @@ class BaseCommand(ABC):
         if self._should_track_state:
             self._initialize_diff_tracker(ctx)
 
-        if self._intention and self._intention.packages:
+        if (
+            self._intention
+            and self._intention.packages
+            and self._intention.intention_type is not ToolIntentionType.REMOVE_PACKAGE
+        ):
             for dep in self._intention.packages:
-                if reviewed_name := self.__typosquatting_protection.coerce(dep.name):
+                if reviewed_name := self.__typosquatting_protection.coerce(
+                    self._intention, dep.name
+                ):
                     dep.corrected_text = dep.original_text.replace(
                         dep.name, reviewed_name
                     )
+                    # NOTE: Mutation here is a workaround, it should be improved in the future.
                     dep.name = reviewed_name
                     self._args[dep.arg_index] = dep.corrected_text
 
@@ -251,29 +242,28 @@ class BaseCommand(ABC):
         self._handle_command_result(ctx, result)
 
     def execute(self, ctx: typer.Context) -> ToolResult:
-        with self._filelock:
-            self.before(ctx)
-            # TODO: Safety should redirect to the proper pip/tool, if the user is
-            # using pip3, it should be redirected to pip3, not pip to avoid any
-            # issues.
+        self.before(ctx)
+        # TODO: Safety should redirect to the proper pip/tool, if the user is
+        # using pip3, it should be redirected to pip3, not pip to avoid any
+        # issues.
 
-            cmd = self.get_command_name()
-            cmd_name = cmd[0]
-            pre_args = [get_unwrapped_command(name=cmd_name)] + cmd[1:]
-            args = pre_args + self.__remove_safety_args(self._args)
+        cmd = self.get_command_name()
+        cmd_name = cmd[0]
+        pre_args = [get_unwrapped_command(name=cmd_name)] + cmd[1:]
+        args = pre_args + self.__remove_safety_args(self._args)
 
-            started_at = time.monotonic()
-            process = subprocess.run(
-                args, capture_output=self._capture_output, env=self.env(ctx)
-            )
+        started_at = time.monotonic()
+        process = subprocess.run(
+            args, capture_output=self._capture_output, env=self.env(ctx)
+        )
 
-            duration_ms = int((time.monotonic() - started_at) * 1000)
+        duration_ms = int((time.monotonic() - started_at) * 1000)
 
-            result = ToolResult(process=process, duration_ms=duration_ms)
+        result = ToolResult(process=process, duration_ms=duration_ms)
 
-            self.after(ctx, result)
+        self.after(ctx, result)
 
-            return result
+        return result
 
     def env(self, ctx: typer.Context):
         """
@@ -318,9 +308,20 @@ class BaseCommand(ABC):
         )
 
 
+@dataclass
+class ParsedCommand:
+    """
+    Represents a parsed command with its hierarchy
+    """
+
+    chain: List[str]  # e.g., ['pip', 'install'] or ['add']
+    intention: ToolIntentionType
+    remaining_args_start: int  # Where options/packages start
+
+
 class ToolCommandLineParser(ABC):
     """
-    Abstract base class for tool command line parsers
+    Base implementation of a command line parser for tools
     """
 
     def __init__(self):
@@ -328,49 +329,254 @@ class ToolCommandLineParser(ABC):
 
     @abstractmethod
     def get_tool_name(self) -> str:
-        """
-        Name of the tool
-        """
         pass
-
-    @property
-    @abstractmethod
-    def intention_mapping(self) -> Dict[str, ToolIntentionType]:
-        """
-        Maps commands to intention types
-        """
-        pass
-
-    def can_handle(self, args: List[str]) -> bool:
-        """
-        Check if this parser can handle the given arguments
-        """
-        if not args or len(args) < 1:
-            return False
-
-        return args[0].lower() in self.intention_mapping
 
     @abstractmethod
-    def parse(self, args: List[str]) -> Optional[CommandToolIntention]:
+    def get_command_hierarchy(self) -> Dict[str, Union[ToolIntentionType, Dict]]:
         """
-        Parse the command line arguments
+        Return command hierarchy only. No option definitions needed.
 
-        Args:
-            args: Command line arguments
-
-        Returns:
-            CommandToolIntention: Parsed command with normalized intention
+        Example:
+        {
+            'add': ToolIntentionType.ADD_PACKAGE,
+            'pip': {
+                'install': ToolIntentionType.ADD_PACKAGE,
+                'uninstall': ToolIntentionType.REMOVE_PACKAGE
+            }
+        }
         """
         pass
 
-    def map_intention(self, command: str) -> ToolIntentionType:
+    @abstractmethod
+    def get_known_flags(self) -> Dict[str, Set[str]]:
         """
-        Map a command to its corresponding intention type
+        Return known flags that don't take values.
+        Format: {command_path: {flag_names}}
 
-        Args:
-            command: Command to map
-
-        Returns:
-            ToolIntentionType: Normalized intention type
+        Example:
+        {
+            'global': {'verbose', 'v', 'quiet', 'q', 'help', 'h'},
+            'install': {'upgrade', 'U', 'dry-run', 'no-deps', 'user'}
+        }
         """
-        return self.intention_mapping.get(command.lower(), ToolIntentionType.UNKNOWN)
+        pass
+
+    def parse(
+        self, args: List[str], start_from: int = 0
+    ) -> Optional[CommandToolIntention]:
+        """
+        Main parsing method
+        """
+
+        parsed_command = self._parse_command_hierarchy(args, start_from)
+        if not parsed_command:
+            return None
+
+        remaining_args = args[parsed_command.remaining_args_start :]
+        options, packages = self._parse_options_and_packages(
+            remaining_args, parsed_command
+        )
+
+        return CommandToolIntention(
+            tool=self._tool_name,
+            command=" ".join(parsed_command.chain),
+            command_chain=parsed_command.chain,
+            intention_type=parsed_command.intention,
+            packages=packages,
+            options=options,
+            raw_args=args.copy(),
+        )
+
+    def _is_known_flag(self, option_key: str, command_chain: List[str]) -> bool:
+        """
+        Check if option is a known flag using command context
+        """
+        known_flags = self.get_known_flags()
+
+        # Try command-specific flags first, then global
+        candidates = []
+        if command_chain:
+            for i in range(len(command_chain), 0, -1):
+                candidates.append(".".join(command_chain[:i]))
+        candidates.append("global")
+
+        for candidate in candidates:
+            if candidate in known_flags and option_key in known_flags[candidate]:
+                return True
+
+        return False
+
+    def _parse_command_hierarchy(
+        self, args: List[str], start_from: int
+    ) -> Optional[ParsedCommand]:
+        """
+        Parse the command hierarchy - stop at first non-command
+        """
+        if not args or start_from >= len(args):
+            return None
+
+        hierarchy = self.get_command_hierarchy()
+        command_chain = []
+        current_level = hierarchy
+        i = start_from
+
+        while i < len(args):
+            arg = args[i].lower()
+
+            # Check if this argument is a valid command at current level
+            if isinstance(current_level, dict) and arg in current_level:
+                command_chain.append(arg)
+                current_level = current_level[arg]
+
+                # If we hit an intention type, we're done with commands
+                if isinstance(current_level, ToolIntentionType):
+                    return ParsedCommand(
+                        chain=command_chain,
+                        intention=current_level,
+                        remaining_args_start=i + 1,
+                    )
+
+            i += 1
+
+        # Check if we ended on a valid intention
+        if isinstance(current_level, ToolIntentionType):
+            return ParsedCommand(
+                chain=command_chain, intention=current_level, remaining_args_start=i
+            )
+
+        return None
+
+    def _parse_options_and_packages(
+        self, args: List[str], parsed_command: ParsedCommand
+    ) -> Tuple[Dict[str, Any], List[Dependency]]:
+        """
+        Simple parsing: hyphens = options, everything else = packages/args
+        """
+
+        options = {}
+        packages = []
+
+        i = 0
+        while i < len(args):
+            arg = args[i]
+
+            if arg.startswith("-"):
+                option_key, option_data, consumed = self._parse_option(
+                    args, i, parsed_command
+                )
+                options[option_key] = option_data
+                i += consumed
+            else:
+                arg_index = parsed_command.remaining_args_start + i
+
+                dep = self._try_parse_package(arg, arg_index, parsed_command)
+
+                if dep:
+                    packages.append(dep)
+                else:
+                    self._store_unknown_argument(options, arg, arg_index)
+
+                i += 1
+
+        return options, packages
+
+    def _parse_option(
+        self, args: List[str], i: int, parsed_command: ParsedCommand
+    ) -> Tuple[str, Dict[str, Any], int]:
+        """
+        Parse a single option, args[i] is expected to be a hyphenated option
+        """
+        arg = args[i]
+        arg_index = parsed_command.remaining_args_start + i
+
+        # Handle --option=value format
+        if "=" in arg:
+            option_part, value_part = arg.split("=", 1)
+            option_key = option_part.lstrip("-")
+            option_data = {
+                "arg_index": arg_index,
+                "raw_option": option_part,
+                "value": value_part,
+            }
+            return option_key, option_data, 1
+
+        # Handle --option, -option formats for known flags
+        option_key = arg.lstrip("-")
+
+        if self._is_known_flag(option_key, parsed_command.chain):
+            # It's a flag - doesn't take value
+            option_data = {
+                "arg_index": arg_index,
+                "raw_option": arg,
+                "value": True,
+            }
+            return option_key, option_data, 1
+
+        # Handle --option value, -option value formats
+        if i + 1 < len(args) and not args[i + 1].startswith("-"):
+            option_data = {
+                "arg_index": arg_index,
+                "raw_option": arg,
+                "value": args[i + 1],
+                "value_index": arg_index + 1,
+            }
+            return option_key, option_data, 2
+
+        # Handle --option, -option formats for unknown flags
+        option_data = {
+            "arg_index": arg_index,
+            "raw_option": arg,
+            "value": True,
+        }
+        return option_key, option_data, 1
+
+    def _should_parse_as_package(self, intention: ToolIntentionType) -> bool:
+        """
+        Check if arguments should be parsed as packages
+        """
+        return intention in [
+            ToolIntentionType.ADD_PACKAGE,
+            ToolIntentionType.REMOVE_PACKAGE,
+            ToolIntentionType.DOWNLOAD_PACKAGE,
+        ]
+
+    def _try_parse_package(
+        self, arg: str, index: int, parsed_command: ParsedCommand
+    ) -> Optional[Dependency]:
+        """
+        Try to parse argument as package, return None if fails
+        """
+        if self._should_parse_as_package(parsed_command.intention):
+            return self._parse_package_spec(arg, index)
+
+        return None
+
+    def _store_unknown_argument(self, options: Dict, arg: str, index: int):
+        """
+        Store non-package arguments in options as unknown
+        """
+        key = f"unknown_{len([k for k in options.keys() if k.startswith('unknown_')])}"
+        options[key] = {
+            "arg_index": index,
+            "value": arg,
+        }
+
+    def _parse_package_spec(
+        self, spec_str: str, arg_index: int
+    ) -> Optional[Dependency]:
+        try:
+            from packaging.requirements import Requirement
+
+            # TODO: pip install . should be excluded
+            req = Requirement(spec_str)
+
+            return Dependency(
+                name=req.name,
+                version_constraint=str(req.specifier),
+                extras=req.extras,
+                arg_index=arg_index,
+                original_text=spec_str,
+            )
+        except Exception:
+            # If spec parsing fails, just ignore for now
+            return None

--- a/safety/tool/intents.py
+++ b/safety/tool/intents.py
@@ -11,6 +11,7 @@ class ToolIntentionType(Enum):
     ADD_PACKAGE = auto()
     REMOVE_PACKAGE = auto()
     UPDATE_PACKAGE = auto()
+    DOWNLOAD_PACKAGE = auto()
     SYNC_PACKAGES = auto()
     LIST_PACKAGES = auto()
     INIT_PROJECT = auto()
@@ -43,6 +44,18 @@ class CommandToolIntention:
     tool: str
     command: str
     intention_type: ToolIntentionType
+    command_chain: List[str] = field(default_factory=list)
     packages: List[Dependency] = field(default_factory=list)
     options: Dict[str, Any] = field(default_factory=dict)
     raw_args: List[str] = field(default_factory=list)
+
+    def modifies_packages(self) -> bool:
+        """
+        Check if this intention type modifies installed packages.
+        """
+        return self.intention_type in {
+            ToolIntentionType.ADD_PACKAGE,
+            ToolIntentionType.REMOVE_PACKAGE,
+            ToolIntentionType.UPDATE_PACKAGE,
+            ToolIntentionType.SYNC_PACKAGES,
+        }

--- a/safety/tool/mixins.py
+++ b/safety/tool/mixins.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Protocol, Tuple, Dict, Optional, runtime_checkable
+from typing import Any, List, Protocol, Tuple, Dict, runtime_checkable
 import typer
 from rich.padding import Padding
 
@@ -8,6 +8,7 @@ from safety.console import main_console as console
 from safety.init.render import render_header, progressive_print
 from safety.models import ToolResult
 import logging
+from .intents import ToolIntentionType, CommandToolIntention
 
 logger = logging.getLogger(__name__)
 
@@ -22,13 +23,6 @@ class AuditableCommand(Protocol):
     def _diff_tracker(self) -> "EnvironmentDiffTracker":
         """
         Provides package tracking functionality.
-        """
-        ...
-
-    @property
-    def _packages(self) -> List[Tuple[str, Optional[str]]]:
-        """
-        Provides the target package list.
         """
         ...
 
@@ -78,11 +72,11 @@ class InstallationAuditMixin:
             progressive_print(warning_messages)
             console.line()
 
-    def render_package_details(self: "AuditableCommand"):
+    def render_package_details(self: "AuditableCommand", packages: List[str]):
         """
         Render details for installed packages.
         """
-        for package_name, _ in self._packages:
+        for package_name in packages:
             console.print(
                 Padding(
                     f"Learn more: [link]https://data.safetycli.com/packages/pypi/{package_name}/[/link]",
@@ -91,7 +85,9 @@ class InstallationAuditMixin:
                 emoji=True,
             )
 
-    def audit_packages(self, ctx: typer.Context) -> Dict[str, Any]:
+    def audit_packages(
+        self, ctx: typer.Context
+    ) -> Tuple[Dict[str, Any], Dict[str, str]]:
         """
         Audit packages based on environment diff tracking.
         Override this method in your command class if needed.
@@ -103,25 +99,26 @@ class InstallationAuditMixin:
             Dict containing audit results
         """
         try:
-            # Check if the instance has a diff tracker and can get a diff
-            # Using getattr to avoid lint errors
             diff_tracker = getattr(self, "_diff_tracker", None)
             if diff_tracker and hasattr(diff_tracker, "get_diff"):
                 added, _, updated = diff_tracker.get_diff()
                 packages = {**added, **updated}
 
                 if hasattr(ctx.obj, "auth") and hasattr(ctx.obj.auth, "client"):
-                    return ctx.obj.auth.client.audit_packages(
-                        [
-                            f"{package_name}=={version[-1] if isinstance(version, tuple) else version}"
-                            for (package_name, version) in packages.items()
-                        ]
+                    return (
+                        ctx.obj.auth.client.audit_packages(
+                            [
+                                f"{package_name}=={version[-1] if isinstance(version, tuple) else version}"
+                                for (package_name, version) in packages.items()
+                            ]
+                        ),
+                        packages,
                     )
         except Exception:
             logger.debug("Audit API failed with error", exc_info=True)
 
         # Always return a dict to satisfy the return type
-        return dict()
+        return dict(), dict()
 
     def handle_installation_audit(self, ctx: typer.Context, result: ToolResult):
         """
@@ -143,9 +140,25 @@ class InstallationAuditMixin:
                 "handle_installation_audit can only be called on instances of AuditableCommand"
             )
 
-        packages_audit = self.audit_packages(ctx)
-        self.render_installation_warnings(ctx, packages_audit)
+        audit_result, packages = self.audit_packages(ctx)
+        self.render_installation_warnings(ctx, audit_result)
 
-        # If command failed, show package details
         if not result.process or result.process.returncode != 0:
-            self.render_package_details()
+            package_names = set(packages.keys())
+
+            # Access _intention safely to keep the protocol minimal and satisfy type checkers
+            intent = getattr(self, "_intention", None)
+            if isinstance(intent, CommandToolIntention):
+                command_intent: CommandToolIntention = intent
+
+                if (
+                    command_intent.intention_type
+                    is not ToolIntentionType.REMOVE_PACKAGE
+                    and command_intent.packages
+                ):
+                    for dep in command_intent.packages:
+                        if dep.name:
+                            package_names.add(dep.name)
+
+            if package_names:
+                self.render_package_details(sorted(package_names))

--- a/safety/tool/poetry/command.py
+++ b/safety/tool/poetry/command.py
@@ -18,7 +18,6 @@ from safety_schemas.models.events.types import ToolType
 from safety.console import main_console as console
 from safety.models import ToolResult
 
-PO_LOCK = "safety-po.lock"
 
 if TYPE_CHECKING:
     from ..environment_diff import EnvironmentDiffTracker
@@ -42,32 +41,9 @@ class PoetryCommand(BaseCommand):
     def get_command_name(self) -> List[str]:
         return ["poetry"]
 
-    def get_lock_path(self) -> str:
-        return PO_LOCK
-
     def get_diff_tracker(self) -> "EnvironmentDiffTracker":
         # pip diff tracker will be enough for poetry
         return PipEnvironmentDiffTracker()
-
-    def should_track_state(self) -> bool:
-        """
-        Determine if the Poetry command will change package dependencies in the virtual environment.
-
-        Returns:
-            bool: True if command will modify installed packages, False otherwise
-        """
-        command_str = " ".join(self._args).lower()
-
-        package_modifying_commands = [
-            "add",
-            "remove",
-            "install",
-            "uninstall",
-            "update",
-            "sync",
-        ]
-
-        return any(cmd in command_str for cmd in package_modifying_commands)
 
     def get_package_list_command(self) -> List[str]:
         """
@@ -153,21 +129,14 @@ class PoetryCommand(BaseCommand):
 
         if intention := parser.parse(args):
             kwargs["intention"] = intention
-            if intention.intention_type is ToolIntentionType.ADD_PACKAGE:
-                return PoetryAddCommand(args, **kwargs)
 
-        return PoetryGenericCommand(args, **kwargs)
+            if intention.modifies_packages():
+                return AuditablePoetryCommand(args, **kwargs)
 
-
-class PoetryGenericCommand(PoetryCommand):
-    pass
+        return PoetryCommand(args, **kwargs)
 
 
-class PoetryAddCommand(PoetryCommand, InstallationAuditMixin):
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        self._packages = []
-
+class AuditablePoetryCommand(PoetryCommand, InstallationAuditMixin):
     def patch_source_option(
         self, args: List[str], new_source: str = "safety"
     ) -> Tuple[Optional[str], List[str]]:
@@ -204,18 +173,6 @@ class PoetryAddCommand(PoetryCommand, InstallationAuditMixin):
         _, modified_args = self.patch_source_option(self._args)
         self._args = modified_args
 
-        # Extract packages from intention for rendering later
-        if self._intention and self._intention.packages:
-            for pkg in self._intention.packages:
-                self._packages.append((pkg.name, pkg.version_constraint))
-
     def after(self, ctx: typer.Context, result: ToolResult):
-        """
-        Run after the command execution. Handle installation audit via mixin.
-
-        Args:
-            ctx: The typer context
-            result: The tool result
-        """
         super().after(ctx, result)
         self.handle_installation_audit(ctx, result)

--- a/safety/tool/poetry/parser.py
+++ b/safety/tool/poetry/parser.py
@@ -1,6 +1,6 @@
-from typing import Dict, List, Optional
+from typing import Dict, Optional, Union, Set
 
-from ..base import ToolCommandLineParser, CommandToolIntention
+from ..base import ToolCommandLineParser
 from ..intents import Dependency, ToolIntentionType
 
 
@@ -8,107 +8,76 @@ class PoetryParser(ToolCommandLineParser):
     def get_tool_name(self) -> str:
         return "poetry"
 
-    @property
-    def intention_mapping(self) -> Dict[str, ToolIntentionType]:
+    def get_command_hierarchy(self) -> Dict[str, Union[ToolIntentionType, Dict]]:
         """
-        Maps specific commands to intention types
+        Allow base parser to recognize poetry commands and intentions.
         """
         return {
             "add": ToolIntentionType.ADD_PACKAGE,
             "remove": ToolIntentionType.REMOVE_PACKAGE,
             "update": ToolIntentionType.UPDATE_PACKAGE,
+            "install": ToolIntentionType.SYNC_PACKAGES,
+            "build": ToolIntentionType.BUILD_PROJECT,
             "show": ToolIntentionType.LIST_PACKAGES,
             "init": ToolIntentionType.INIT_PROJECT,
-            "build": ToolIntentionType.BUILD_PROJECT,
-            "install": ToolIntentionType.SYNC_PACKAGES,
         }
 
-    def parse(self, args: List[str]) -> Optional[CommandToolIntention]:
+    def get_known_flags(self) -> Dict[str, Set[str]]:
         """
-        Parse the command line arguments into a CommandToolIntention object.
-
-        Args:
-            args (List[str]): Command line arguments
-
-        Returns:
-            Optional[CommandToolIntention]: Parsed command tool intention
+        Flags that DO NOT take a value, derived from `poetry --help` and subcommand helps.
         """
-        if not self.can_handle(args):
-            return None
-
-        command = args[0].lower()
-        intention_type = self.map_intention(command)
-        options = {}
-        packages = []
-        raw_args = args.copy()
-
-        # Process command arguments based on intention type
-        i = 1  # Skip command
-        while i < len(args):
-            arg = args[i]
-
-            if arg.startswith("-"):
-                # Handle options
-                option_key = arg.lstrip("-")
-
-                # Handle option with value
-                if i + 1 < len(args) and not args[i + 1].startswith("-"):
-                    option_value = args[i + 1]
-                    options[option_key] = {
-                        "arg_index": i,
-                        "raw_option": arg,
-                        "value": option_value,
-                        "value_index": i + 1,
-                    }
-                    i += 2
-                else:
-                    # Flag option (no value)
-                    options[option_key] = {
-                        "arg_index": i,
-                        "raw_option": arg,
-                        "value": True,
-                    }
-                    i += 1
-            else:
-                # Parse non-option arguments
-                if intention_type == ToolIntentionType.ADD_PACKAGE:
-                    try:
-                        # Parse package specification
-                        dep = self._parse_package_spec(arg, i)
-                        if not dep:
-                            # Let's skip this dependency
-                            i += 1
-                            continue
-
-                        # Check if this is a dev dependency
-                        is_dev = any(opt in ["dev", "D"] for opt in options.keys())
-                        dep.is_dev_dependency = is_dev
-
-                        packages.append(dep)
-                    except ValueError:
-                        # Not a valid package spec, store as unknown option
-                        options[f"unknown_{len(options)}"] = {
-                            "arg_index": i,
-                            "value": arg,
-                        }
-                elif intention_type in [
-                    ToolIntentionType.REMOVE_PACKAGE,
-                    ToolIntentionType.UPDATE_PACKAGE,
-                ]:
-                    # Handle packages for remove/update commands
-                    # These often have simpler formats than add commands
-                    dep = Dependency(name=arg, arg_index=i, original_text=arg)
-                    packages.append(dep)
-                i += 1
-
-        return CommandToolIntention(
-            tool=self._tool_name,
-            command=command,
-            intention_type=intention_type,
-            packages=packages,
-            options=options,
-            raw_args=raw_args,
-        )
+        return {
+            "global": {
+                "help",
+                "h",
+                "quiet",
+                "q",
+                "version",
+                "V",
+                "ansi",
+                "no-ansi",
+                "no-interaction",
+                "no-plugins",
+                "no-cache",
+                "verbose",
+                "v",
+                "vv",
+                "vvv",
+            },
+            "add": {
+                "dev",
+                "D",
+                "editable",
+                "e",
+                "allow-prereleases",
+                "dry-run",
+                "lock",
+            },
+            "remove": {
+                "dev",
+                "D",
+                "dry-run",
+                "lock",
+            },
+            "update": {
+                "sync",
+                "dry-run",
+                "lock",
+            },
+            "install": {
+                "sync",
+                "no-root",
+                "no-directory",
+                "dry-run",
+                "all-extras",
+                "all-groups",
+                "only-root",
+                "compile",
+            },
+            "build": {
+                "clean",
+            },
+        }
 
     def _parse_package_spec(
         self, spec_str: str, arg_index: int

--- a/safety/tool/typosquatting.py
+++ b/safety/tool/typosquatting.py
@@ -8,6 +8,7 @@ from typing import Tuple, List
 
 from safety.console import main_console as console
 from rich.prompt import Prompt
+from .intents import CommandToolIntention, ToolIntentionType
 
 logger = logging.getLogger(__name__)
 
@@ -44,11 +45,12 @@ class TyposquattingProtection:
 
         return (True, package_name)
 
-    def coerce(self, dependency_name: str) -> str:
+    def coerce(self, intention: CommandToolIntention, dependency_name: str) -> str:
         """
         Coerce a package name to its correct name if it is a typosquatting attempt.
 
         Args:
+            intention: CommandToolIntention object
             dependency_name: Name of the package to coerce
 
         Returns:
@@ -57,7 +59,14 @@ class TyposquattingProtection:
         (valid, candidate_package_name) = self.check_package(dependency_name)
 
         if not valid:
-            prompt = f"You are about to install {dependency_name} package. Did you mean to install {candidate_package_name}?"
+            action = "install"
+
+            if intention.intention_type == ToolIntentionType.DOWNLOAD_PACKAGE:
+                action = "download"
+            elif intention.intention_type == ToolIntentionType.BUILD_PROJECT:
+                action = "build"
+
+            prompt = f"You are about to {action} {dependency_name} package. Did you mean to {action} {candidate_package_name}?"
             answer = Prompt.ask(
                 prompt=prompt,
                 choices=["y", "n"],

--- a/safety/tool/uv/parser.py
+++ b/safety/tool/uv/parser.py
@@ -1,0 +1,134 @@
+from typing import Dict
+
+from ..base import ToolCommandLineParser
+from ..intents import ToolIntentionType
+from typing import Union
+
+
+class UvParser(ToolCommandLineParser):
+    def get_tool_name(self) -> str:
+        return "uv"
+
+    def get_command_hierarchy(self) -> Dict[str, Union[ToolIntentionType, Dict]]:
+        """
+        Context for command hierarchy parsing
+        """
+        return {
+            # 2-level commands
+            "add": ToolIntentionType.ADD_PACKAGE,
+            "remove": ToolIntentionType.REMOVE_PACKAGE,
+            "build": ToolIntentionType.BUILD_PROJECT,
+            # 3-level commands
+            "pip": {
+                "install": ToolIntentionType.ADD_PACKAGE,
+                "uninstall": ToolIntentionType.REMOVE_PACKAGE,
+                "download": ToolIntentionType.DOWNLOAD_PACKAGE,
+            },
+            "tool": {
+                "install": ToolIntentionType.ADD_PACKAGE,
+                "uninstall": ToolIntentionType.REMOVE_PACKAGE,
+            },
+        }
+
+    def get_known_flags(self) -> Dict[str, set]:
+        """
+        Define flags that DON'T take values for uv.
+        These were derived from `uv --help` and subcommand helps.
+        """
+        return {
+            "global": {
+                # Global options
+                "quiet",
+                "q",
+                "verbose",
+                "v",
+                "native-tls",
+                "offline",
+                "no-progress",
+                "no-config",
+                "help",
+                "h",
+                "version",
+                "V",
+                # Python options that are flags
+                "managed-python",
+                "no-managed-python",
+                "no-python-downloads",
+            },
+            # 2-level commands
+            "add": {
+                # From `uv add --help`
+                "no-sync",
+                "locked",
+                "frozen",
+                "active",
+                "workspace",
+                "no-workspace",
+                "no-install-project",
+                "no-install-workspace",
+                # Resolver/installer/build/cache flags inherited
+                "upgrade",
+                "no-sources",
+                "reinstall",
+                "compile-bytecode",
+                "no-build-isolation",
+                "no-build",
+                "no-binary",
+                "no-cache",
+                "refresh",
+            },
+            "remove": {
+                "dev",
+                "no-sync",
+                "active",
+                "locked",
+                "frozen",
+                # Inherited flags (see sections in help)
+                "upgrade",
+                "no-sources",
+                "reinstall",
+                "compile-bytecode",
+                "no-build-isolation",
+                "no-build",
+                "no-binary",
+                "no-cache",
+                "refresh",
+            },
+            # 3-level pip commands
+            "pip.install": {
+                # pip install-like flags in uv
+                "user",
+                "upgrade",
+                "no-sources",
+                "reinstall",
+                "compile-bytecode",
+                "no-build-isolation",
+                "no-build",
+                "no-binary",
+                "no-cache",
+                "refresh",
+            },
+            "pip.uninstall": {
+                "system",
+                "break-system-packages",
+                "no-break-system-packages",
+                "dry-run",
+                # global/cache flags also apply
+                "no-cache",
+            },
+            "tool.install": {
+                "editable",
+                "e",
+                "force",
+                # inherited sections
+                "upgrade",
+                "no-sources",
+                "reinstall",
+                "compile-bytecode",
+                "no-build-isolation",
+                "no-build",
+                "no-binary",
+                "no-cache",
+                "refresh",
+            },
+        }


### PR DESCRIPTION
Ensure add, sync, and update and other commands are included in Firewall's audit trail alongside existing package operations.
