### PR TITLE
feat: add non-interactive mode to disable linking prompts in CI/CD (#741)

### DIFF
--- a/safety/scan/command.py
+++ b/safety/scan/command.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 
 import json
+import os
 import sys
 from typing import Any, Dict, List, Optional, Set, Tuple, Callable
 
@@ -886,10 +887,22 @@ def scan(
         Optional[List[str]],
         typer.Option("--filter", help="Filter output by specific top-level JSON keys."),
     ] = None,
+    non_interactive: Annotated[
+        bool,
+        typer.Option(
+            "--non-interactive",
+            help="Disable interactive prompts for CI/CD environments. Can also be set via SAFETY_NONINTERACTIVE environment variable.",
+            show_default=False,
+            envvar="SAFETY_NONINTERACTIVE",
+        ),
+    ] = False,
 ):
     """
     Scans a project (defaulted to the current directory) for supply-chain security and configuration issues
     """
+
+    # Store non-interactive flag in context for use by decorators
+    ctx.obj.non_interactive = non_interactive
 
     # Step 1: Validate inputs and initialize settings
     validate_authentication(ctx)

--- a/safety/scan/decorators.py
+++ b/safety/scan/decorators.py
@@ -79,9 +79,15 @@ def scan_project_command_init(func):
             # TODO: Move this to be injected by a codebase service
             from safety.init.main import verify_project
 
+            # Determine link behavior based on non-interactive flag
             link_behavior = "prompt"
-
-            if unverified_project.created:
+            
+            # Check for non-interactive mode from CLI flag or environment variable
+            non_interactive = getattr(ctx.obj, 'non_interactive', False) or os.getenv('SAFETY_NONINTERACTIVE', '').lower() in ('1', 'true', 'yes')
+            
+            if non_interactive:
+                link_behavior = "never"
+            elif unverified_project.created:
                 link_behavior = "always"
 
             verify_project(

--- a/tests/scan/test_command.py
+++ b/tests/scan/test_command.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import tempfile
 from importlib.metadata import version
@@ -6,7 +7,7 @@ from packaging.version import Version
 from safety.auth.models import Auth
 from safety.cli import cli
 from safety.console import main_console as console
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 
 class TestScanCommand(unittest.TestCase):
@@ -55,3 +56,59 @@ class TestScanCommand(unittest.TestCase):
             ["--stage", "cicd", "scan", "--target", self.target, "--output", "screen"],
         )
         self.assertEqual(result.exit_code, 1)
+
+    @patch("safety.scan.decorators.verify_project")
+    @patch.object(Auth, "is_valid", return_value=True)
+    @patch("safety.auth.utils.SafetyAuthSession.get_authentication_type", return_value="token")
+    def test_scan_non_interactive_flag(self, mock_get_auth_type, mock_is_valid, mock_verify_project):
+        """Test that --non-interactive flag sets link_behavior to 'never'"""
+        # Setup mock to capture verify_project call
+        mock_verify_project.return_value = (True, "found")
+
+        result = self.runner.invoke(
+            self.cli,
+            ["scan", "--target", self.target, "--non-interactive", "--output", "json"]
+        )
+
+        # Verify verify_project was called with link_behavior='never'
+        if mock_verify_project.called:
+            call_kwargs = mock_verify_project.call_args.kwargs
+            self.assertEqual(call_kwargs.get('link_behavior'), 'never')
+
+    @patch("safety.scan.decorators.verify_project")
+    @patch.object(Auth, "is_valid", return_value=True)
+    @patch("safety.auth.utils.SafetyAuthSession.get_authentication_type", return_value="token")
+    def test_scan_non_interactive_env_var(self, mock_get_auth_type, mock_is_valid, mock_verify_project):
+        """Test that SAFETY_NONINTERACTIVE environment variable sets link_behavior to 'never'"""
+        # Setup mock to capture verify_project call
+        mock_verify_project.return_value = (True, "found")
+
+        # Test with env var set to 1
+        result = self.runner.invoke(
+            self.cli,
+            ["scan", "--target", self.target, "--output", "json"],
+            env={"SAFETY_NONINTERACTIVE": "1"}
+        )
+
+        # Verify verify_project was called with link_behavior='never'
+        if mock_verify_project.called:
+            call_kwargs = mock_verify_project.call_args.kwargs
+            self.assertEqual(call_kwargs.get('link_behavior'), 'never')
+
+    @patch("safety.scan.decorators.verify_project")
+    @patch.object(Auth, "is_valid", return_value=True)
+    @patch("safety.auth.utils.SafetyAuthSession.get_authentication_type", return_value="token")
+    def test_scan_interactive_default(self, mock_get_auth_type, mock_is_valid, mock_verify_project):
+        """Test that interactive mode (default) uses 'prompt' link_behavior"""
+        # Setup mock to capture verify_project call
+        mock_verify_project.return_value = (True, "linked")
+
+        result = self.runner.invoke(
+            self.cli,
+            ["scan", "--target", self.target, "--output", "json"]
+        )
+
+        # Verify verify_project was called with link_behavior='prompt' (default)
+        if mock_verify_project.called:
+            call_kwargs = mock_verify_project.call_args.kwargs
+            self.assertEqual(call_kwargs.get('link_behavior'), 'prompt')


### PR DESCRIPTION
Fixes #741: Added --non-interactive flag\n- Prevents user prompts in CI/CD\n- Environment variable support\n- Critical for automation pipelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>