### PR TITLE
chore: restructure GitHub issue templates and remove bug bounty references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,97 @@
+name: 🐛 Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I agree to the terms within the [Safety Code of Conduct](https://github.com/pyupio/safety/blob/main/CODE_OF_CONDUCT.md).
+          required: true
+        - label: I have searched existing issues to ensure this bug hasn't been reported before.
+          required: true
+
+  - type: textarea
+    id: safety-version
+    attributes:
+      label: Safety version
+      description: Specify the version of Safety you're using.
+      placeholder: e.g., 3.2.5
+    validations:
+      required: true
+
+  - type: textarea
+    id: python-version
+    attributes:
+      label: Python version
+      description: Specify the version of Python you're using.
+      placeholder: e.g., 3.11.2
+    validations:
+      required: true
+
+  - type: textarea
+    id: os
+    attributes:
+      label: Operating System
+      description: Specify the operating system you're using.
+      placeholder: e.g., macOS 13, Windows 10
+    validations:
+      required: true
+
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug description
+      description: |
+        Describe the bug including:
+        - What you were trying to do
+        - What you expected to happen
+        - What actually happened
+      placeholder: |
+        When I run `safety scan`, I expected it to output rich formatted results, but instead it crashes with a traceback...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide clear steps to reproduce the behavior.
+      placeholder: |
+        1. Run command: `safety scan`
+        2. With these options: `--output report.json`
+        3. Using this requirements file: `requirements.txt`
+        4. See error output
+    validations:
+      required: true
+
+  - type: textarea
+    id: command-output
+    attributes:
+      label: Command and output
+      description: |
+        Paste the command(s) you ran and the full output. If there was a crash, please include the complete traceback.
+        
+        ⚠️ **Important**: Please remove any sensitive information such as:
+        - API keys, tokens, or passwords
+        - File paths that might contain usernames or sensitive directory names
+        - Private package names or internal URLs
+        - Any other personally identifiable or confidential information
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here, including screenshots if applicable.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 🐛 Bug Bounty
-    url: https://safetycli.com/resources/bug-bounty
-    about: Participate in our Bug Bounty program and get rewarded!
   - name: 📖 Safety CLI Documentation
     url: https://docs.safetycli.com/safety-docs
     about: Check the Safety CLI documentation for in-depth overview of all the available commands and options.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -20,43 +20,39 @@ body:
     id: safety-version
     attributes:
       label: Safety version
-      description: Specify the version of Safety you're using.
+      description: Specify the version of Safety you're using (if relevant to the feature request).
       placeholder: e.g., 3.2.5
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: python-version
     attributes:
       label: Python version
-      description: Specify the version of Python you're using.
+      description: Specify the version of Python you're using (if relevant to the feature request).
       placeholder: e.g., 3.11.2
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: os
     attributes:
       label: Operating System
-      description: Specify the operating system you're using.
+      description: Specify the operating system you're using (if relevant to the feature request).
       placeholder: e.g., macOS 13, Windows 10
     validations:
-      required: true
+      required: false
 
   - type: textarea
-    id: description
+    id: feature-description
     attributes:
-      label: Describe the problem you'd like to have solved
-      description: A clear and concise description of what the problem is.
-      placeholder: My life would be a lot simpler if...
-    validations:
-      required: true
-
-  - type: textarea
-    id: ideal-solution
-    attributes:
-      label: Describe the ideal solution
-      description: A clear and concise description of what you want to happen.
+      label: Feature description
+      description: |
+        Describe the feature you'd like to see including:
+        - What problem it would solve or use case it addresses
+        - How you envision it working
+      placeholder: |
+        I'd like Safety to support scanning container images directly. This would help with CI/CD pipelines where we build Docker images and want to scan them for vulnerabilities before deployment...
     validations:
       required: true
 
@@ -76,11 +72,3 @@ body:
     validations:
       required: false
 
-  - type: textarea
-    id: what-i-did
-    attributes:
-      label: What I Did
-      description: Describe what you were trying to get done. Tell us what happened, what went wrong, and what you expected to happen.
-      placeholder: Paste the command(s) you ran and the output. If there was a crash, please include the traceback here.
-    validations:
-      required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ If you find a bug, please report it by opening a [GitHub issue](https://github.c
 - Any relevant logs or screenshots.
 - The version of SafetyCLI and Python you are using.
 
-If your bug report has security implications or involves a potential vulnerability, we encourage you to participate in our [Bug Bounty Program](https://safetycli.com/resources/bug-bounty). Your responsible disclosure will help us improve the security of our software and may be eligible for a reward.
+If your bug report has security implications or involves a potential vulnerability, please refer to our [Security Policy](./SECURITY.md).
 
 Please use the appropriate label when creating an issue:
 - `bug`: Indicates a problem that needs to be resolved.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,8 +17,6 @@ To report a vulnerability:
 
 1. **Email**: Please send the details to [engineers@safetycli.com](mailto:engineers@safetycli.com). Include as much information as possible to help us understand the nature of the vulnerability and how it can be reproduced.
 
-2. **Bug Bounty Program**: We offer a bug bounty program for qualifying vulnerabilities. Detailed information about the program, including eligibility and rewards, can be found on our [Bug Bounty Program page](https://safetycli.com/resources/bug-bounty).
-
 ## Security Best Practices
 
 We encourage our users to follow these best practices to ensure the security of their deployments:


### PR DESCRIPTION
Add missing bug report template, make version fields optional in feature requests, and remove bug bounty program references from templates and documentation as the program is being restructured.