### PR TITLE
chore: set minimum tenacity version to 8.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "pydantic>=2.6.0",
   "requests", # TODO: To be replaced by httpx or aiohttp
   "httpx",
-  "tenacity",
+  "tenacity>=8.1.0",
   "ruamel.yaml>=0.17.21",
   "safety-schemas==0.0.16",
   # TODO: To be removed after migrate away from pkg_resources


### PR DESCRIPTION
Update tenacity dependency to require version 8.1.0 or higher to ensure compatibility with wait_exponential_jitter functionality that was added in that version and is used by the codebase.
