### PR TITLE
fix: replace deprecated pkg_resources with importlib.metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,8 +158,6 @@ dependencies = [
   "tenacity",
   "ruamel.yaml>=0.17.21",
   "safety-schemas==0.0.16",
-  # TODO: To be removed after migrate away from pkg_resources
-  "setuptools>=65.5.1",
   "typer>=0.12.1",
   "typing-extensions>=4.7.1",
   "nltk>=3.9",


### PR DESCRIPTION
pkg_resources will be removed as early as 2025-11-30. Migrated to `importlib.metadata` for getting importable packages to ensure compatibility with future Python versions.