### PR TITLE
ci: separate checksum artifacts for signed and unsigned builds

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -453,17 +453,19 @@ jobs:
 
       - name: Upload checksums
         uses: actions/upload-artifact@v4
+        if: inputs.is-release != true
         with:
           name: checksums
           path: |
             artifacts/SHASUMS256.txt
           compression-level: 0
 
-      - name: Upload signed checksums.txt.cosign.bundle
+      - name: Upload checksums with signature
         if: inputs.is-release == true
         uses: actions/upload-artifact@v4
         with:
           name: checksums
           path: |
+            artifacts/SHASUMS256.txt
             artifacts/SHASUMS256.txt.cosign.bundle
           compression-level: 0


### PR DESCRIPTION
Prevents artifact name collision by using distinct names for checksums with and without signatures.
