### PR TITLE
fix: return non-zero exit code when vulnerabilities are detected

### DIFF
--- a/safety/scan/command.py
+++ b/safety/scan/command.py
@@ -951,8 +951,6 @@ def scan(
         ):
             # Update counts and track vulnerabilities
             count += len(analyzed_file.dependency_results.dependencies)
-            if exit_code == 0 and analyzed_file.dependency_results.failed:
-                exit_code = EXIT_CODE_VULNERABILITIES_FOUND
 
             affected_specifications = (
                 analyzed_file.dependency_results.get_affected_specifications()
@@ -985,6 +983,12 @@ def scan(
                     vulns_to_report = sort_and_filter_vulnerabilities(
                         spec.vulnerabilities, key_func=sort_vulns_by_score
                     )
+
+                    # Set exit code if there are non-ignored vulnerabilities
+                    # This ensures we return non-zero exit code when vulnerabilities
+                    # are detected, regardless of policy configuration
+                    if exit_code == 0 and vulns_to_report:
+                        exit_code = EXIT_CODE_VULNERABILITIES_FOUND
                     critical_vulns_count = count_critical_vulnerabilities(
                         vulns_to_report
                     )

--- a/tests/scan/test_command.py
+++ b/tests/scan/test_command.py
@@ -6,7 +6,78 @@ from packaging.version import Version
 from safety.auth.models import Auth
 from safety.cli import cli
 from safety.console import main_console as console
-from unittest.mock import patch
+from safety.scan.command import sort_and_filter_vulnerabilities
+from unittest.mock import patch, MagicMock
+
+
+class TestSortAndFilterVulnerabilities(unittest.TestCase):
+    """Tests for sort_and_filter_vulnerabilities function"""
+
+    def test_filters_ignored_vulnerabilities(self):
+        """Test that ignored vulnerabilities are filtered out"""
+        vuln1 = MagicMock()
+        vuln1.ignored = False
+        vuln1.score = 7.5
+
+        vuln2 = MagicMock()
+        vuln2.ignored = True
+        vuln2.score = 9.0
+
+        vuln3 = MagicMock()
+        vuln3.ignored = False
+        vuln3.score = 5.0
+
+        vulnerabilities = [vuln1, vuln2, vuln3]
+
+        result = sort_and_filter_vulnerabilities(
+            vulnerabilities,
+            key_func=lambda v: v.score
+        )
+
+        # Should only have 2 non-ignored vulnerabilities
+        self.assertEqual(len(result), 2)
+        # vuln2 (ignored) should not be in results
+        self.assertNotIn(vuln2, result)
+        # Results should be sorted by score descending
+        self.assertEqual(result[0], vuln1)  # score 7.5
+        self.assertEqual(result[1], vuln3)  # score 5.0
+
+    def test_empty_list_when_all_ignored(self):
+        """Test that empty list is returned when all vulnerabilities are ignored"""
+        vuln1 = MagicMock()
+        vuln1.ignored = True
+
+        vuln2 = MagicMock()
+        vuln2.ignored = True
+
+        vulnerabilities = [vuln1, vuln2]
+
+        result = sort_and_filter_vulnerabilities(
+            vulnerabilities,
+            key_func=lambda v: 0
+        )
+
+        self.assertEqual(len(result), 0)
+
+    def test_non_empty_list_triggers_exit_code(self):
+        """
+        Test that non-ignored vulnerabilities should trigger exit code.
+        This tests the condition: if exit_code == 0 and vulns_to_report:
+        """
+        vuln1 = MagicMock()
+        vuln1.ignored = False
+        vuln1.score = 7.5
+
+        vulnerabilities = [vuln1]
+
+        result = sort_and_filter_vulnerabilities(
+            vulnerabilities,
+            key_func=lambda v: v.score
+        )
+
+        # Non-empty result should evaluate to True for exit code check
+        self.assertTrue(bool(result))
+        self.assertEqual(len(result), 1)
 
 
 class TestScanCommand(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Fixes exit code always being 0 when vulnerabilities are detected without a policy file
- Exit code is now set based on non-ignored vulnerabilities found, not policy configuration
- Added unit tests for the `sort_and_filter_vulnerabilities` function

## Problem

When running `safety scan` without a policy file, the exit code was always 0 even when vulnerabilities were detected. This was because the exit code logic depended on `dependency_results.failed`, which was only set to `True` when `config.depedendency_vulnerability.fail_on.enabled` was `True` (requires policy file configuration).

## Solution

Changed the exit code logic to set `EXIT_CODE_VULNERABILITIES_FOUND` when there are non-ignored vulnerabilities in the scan results (`vulns_to_report`), regardless of policy configuration.

## Test plan

- [ ] Added unit tests for `sort_and_filter_vulnerabilities` function
- [x] All existing scan tests pass
- [x] Verified the fix addresses the reported issue in #821

Fixes #821