### PR TITLE
fix(cli): correct typos in check command docstring

### DIFF
--- a/safety/cli.py
+++ b/safety/cli.py
@@ -545,7 +545,7 @@ def check(
     json_version,
 ):
     """
-    [underline][DEPRECATED][/underline] `check` has been replaced by the `scan` command, and will be unsupported beyond 1 June 2024.Find vulnerabilities at a target file or enviroment.
+    [underline][DEPRECATED][/underline] `check` has been replaced by the `scan` command, and will be unsupported beyond 1 June 2024. Find vulnerabilities at a target file or environment.
     """
     LOG.info("Running check command")
 


### PR DESCRIPTION
## Summary

- Fixed misspelling: `enviroment` → `environment` in the `check` command docstring
- Added missing space after period: `2024.Find` → `2024. Find`

## Related Issue

Relates to #574 (Correct Typographical Errors)

## Changes

Single line fix in `safety/cli.py` — the deprecated `check` command's docstring had a misspelled word and missing whitespace between sentences.