### PR TITLE
fix(system-scan): resolve tool detection for versioned Windows executables

### DIFF
--- a/safety/system_scan/scanner/detectors/tools/main.py
+++ b/safety/system_scan/scanner/detectors/tools/main.py
@@ -57,8 +57,8 @@ class ToolDetector:
         if not fs.is_file(path) or not fs.is_executable(path):
             return None
 
-        name = path.stem.lower()
-        return self.TOOL_PATTERNS.get(name)
+        base, _, _ = path.name.lower().partition(".")
+        return self.TOOL_PATTERNS.get(base)
 
     def _get_stable_id(self, path: Path, fs: FsRuntime) -> str:
         """Generate stable ID based on inode."""


### PR DESCRIPTION
On Windows, versioned tool names like `pip3.14.exe` were not detected because `Path.stem` produces "pip3.14" (stripping only the `.exe`), which has no match in `TOOL_PATTERNS`. On Unix, `pip3.14` resolves correctly to stem "pip3" because pathlib treats ".14" as the suffix.

This approach fixes that issue and now also catches executable backups (e.g., pip.bak.exe, git.old.exe) that could be invoked as real tools.