### PR TITLE
fix: drop FF for MDM authd cases

### DIFF
--- a/safety/system_scan/command.py
+++ b/safety/system_scan/command.py
@@ -16,10 +16,12 @@ from ..cli_util import (
     get_command_for,
     pass_safety_cli_obj,
     CommandType,
+    FeatureType,
 )
 from safety.constants import (
     DEFAULT_EPILOG,
     CONTEXT_COMMAND_TYPE,
+    CONTEXT_FEATURE_TYPE,
     EXIT_CODE_INVALID_AUTH_CREDENTIAL,
     get_required_config_setting,
 )
@@ -52,7 +54,7 @@ CLI_SYSTEM_SCAN_COMMAND_HELP = (
         "allow_extra_args": True,
         "ignore_unknown_options": True,
         CONTEXT_COMMAND_TYPE: CommandType.BETA,
-        # CONTEXT_FEATURE_TYPE: FeatureType.PLATFORM,  TODO: We're disabling this until we have feature flags working with the new MDM auth
+        CONTEXT_FEATURE_TYPE: FeatureType.PLATFORM,
     },
 )
 @pass_safety_cli_obj

--- a/tests/auth/test_auth_utils.py
+++ b/tests/auth/test_auth_utils.py
@@ -40,6 +40,7 @@ class TestUtils(unittest.TestCase):
         mock_initialize = Mock(side_effect=InvalidCredentialError())
         mock_client = Mock()
         mock_client.initialize = mock_initialize
+        mock_client.has_machine_token = False
         mock_auth = Mock()
         mock_auth.platform = mock_client
         mock_safety_cli.auth = mock_auth
@@ -68,6 +69,7 @@ class TestUtils(unittest.TestCase):
             patch("safety.auth.utils.setattr") as mock_setattr,
         ):
             mock_safety_cli = MockSafetyCLI.return_value
+            mock_safety_cli.auth.platform.has_machine_token = False
 
             initialize(ctx, refresh=False)
 
@@ -111,6 +113,7 @@ class TestUtils(unittest.TestCase):
         )
         mock_client = Mock()
         mock_client.initialize = mock_initialize
+        mock_client.has_machine_token = False
         mock_auth = Mock()
         mock_auth.platform = mock_client
         mock_safety_cli.auth = mock_auth


### PR DESCRIPTION
MDM doesn't support yet FF, this change unblocks the commands when CLI is using machine tokens.

