### PR TITLE
fix(logging): add context to bare and generic error log messages

### DIFF
--- a/safety/auth/server.py
+++ b/safety/auth/server.py
@@ -112,7 +112,7 @@ def auth_process(
         return platform.fetch_user_info()
 
     except Exception as e:
-        LOG.exception(e)
+        LOG.exception("Authentication server error: %s", e)
         sys.exit(1)
 
 

--- a/safety/safety.py
+++ b/safety/safety.py
@@ -1182,7 +1182,10 @@ def process_fixes_scan(
             )
         except Exception:
             LOG.error(
-                "Error getting upper remediation version, ignoring", exc_info=True
+                "Error parsing upper remediation version %r for %s, ignoring",
+                spec.remediation.closest_secure.upper,
+                spec,
+                exc_info=True,
             )
 
         try:
@@ -1193,14 +1196,19 @@ def process_fixes_scan(
             )
         except Exception:
             LOG.error(
-                "Error getting lower remediation version, ignoring", exc_info=True
+                "Error parsing lower remediation version %r for %s, ignoring",
+                spec.remediation.closest_secure.lower,
+                spec,
+                exc_info=True,
             )
 
         try:
             recommended = Version(spec.remediation.recommended)
         except Exception:
             LOG.error(
-                "Error getting recommended version for remediation, ignoring",
+                "Error parsing recommended version %r for %s, ignoring",
+                spec.remediation.recommended,
+                spec,
                 exc_info=True,
             )
 

--- a/safety/scan/util.py
+++ b/safety/scan/util.py
@@ -103,7 +103,7 @@ class GIT:
             )
         except Exception as e:
             LOG.exception(
-                "Failed to run git command %r: %s", " ".join(self.git + cmd), e
+                "Failed to run git command %r: %s", " ".join(str(p) for p in self.git + cmd), e
             )
 
         return None

--- a/safety/scan/util.py
+++ b/safety/scan/util.py
@@ -102,7 +102,9 @@ class GIT:
                 .strip()
             )
         except Exception as e:
-            LOG.exception(e)
+            LOG.exception(
+                "Failed to run git command %r: %s", " ".join(self.git + cmd), e
+            )
 
         return None
 


### PR DESCRIPTION
## Summary

Addresses #577 by improving three error log calls that were either bare (no message) or generic (no context about what failed).

### Changes

**`safety/scan/util.py`**

`__run__` logged `LOG.exception(e)` with no message when a git command failed. The log now includes the command string so it is clear which git invocation caused the error:

```python
# before
LOG.exception(e)

# after
LOG.exception("Failed to run git command %r: %s", " ".join(self.git + cmd), e)
```

**`safety/auth/server.py`**

The authentication completion handler logged a bare `LOG.exception(e)`. Added a descriptive prefix so the log entry is self-explanatory:

```python
# before
LOG.exception(e)

# after
LOG.exception("Authentication server error: %s", e)
```

**`safety/safety.py`** (remediation version parsing)

Three `LOG.error` calls said only "Error getting X version, ignoring" with no indication of which package or what version string caused the failure. The messages now include the unparseable version string and the package spec:

```python
# before
LOG.error("Error getting upper remediation version, ignoring", exc_info=True)

# after
LOG.error(
    "Error parsing upper remediation version %r for %s, ignoring",
    spec.remediation.closest_secure.upper,
    spec,
    exc_info=True,
)
```

These are pure logging changes with no impact on runtime behaviour.