### PR TITLE
fix(events): support httpx without NetworkError

### DIFF
--- a/safety/auth/enrollment.py
+++ b/safety/auth/enrollment.py
@@ -11,6 +11,7 @@ import httpx
 
 from safety.constants import get_required_config_setting
 from safety.errors import EnrollmentTransientFailure
+from safety.httpx_compat import httpx_transient_error_types
 
 if TYPE_CHECKING:
     from safety.platform.client import SafetyPlatformClient
@@ -27,7 +28,7 @@ def call_enrollment_endpoint(
 ) -> dict:
     """Public wrapper — delegates to platform_client.enroll().
 
-    Catches transient network errors (httpx.NetworkError, httpx.TimeoutException)
+    Catches transient network errors and httpx.TimeoutException
     that tenacity re-raises after retry exhaustion and wraps them in
     EnrollmentTransientFailure (exit code 75) so MDM orchestrators can
     distinguish retryable failures from permanent ones.
@@ -60,7 +61,7 @@ def call_enrollment_endpoint(
     # Broader than @retry's types: also wraps ReadError/WriteError/CloseError
     # (transient, but not retried) as exit-code 75 for MDM orchestrators.
     # Excludes ProtocolError / UnsupportedProtocol (non-transient config bugs).
-    except (httpx.NetworkError, httpx.TimeoutException) as exc:
+    except httpx_transient_error_types() as exc:
         raise EnrollmentTransientFailure(
             f"Enrollment failed after retries: {exc}"
         ) from exc

--- a/safety/events/handlers/common.py
+++ b/safety/events/handlers/common.py
@@ -16,6 +16,7 @@ from tenacity import (
 )
 import tenacity
 
+from safety.httpx_compat import httpx_retry_error_types
 from safety.meta import get_identifier, get_meta_http_headers, get_version
 
 from ..types import (
@@ -167,9 +168,7 @@ class SecurityEventsHandler(EventHandler[SecurityEventTypes]):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=0.1, min=0.2, max=1.0),
-        retry=retry_if_exception_type(
-            (httpx.NetworkError, httpx.TimeoutException, httpx.HTTPStatusError)
-        ),
+        retry=retry_if_exception_type(httpx_retry_error_types()),
         before_sleep=before_sleep_log(logging.getLogger("api_client"), logging.WARNING),
     )
     async def _send_events(

--- a/safety/httpx_compat.py
+++ b/safety/httpx_compat.py
@@ -1,0 +1,39 @@
+from typing import Any, Tuple, Type
+
+import httpx
+
+
+def httpx_network_error_types(
+    httpx_module: Any = httpx,
+) -> Tuple[Type[BaseException], ...]:
+    """Return httpx network exception classes across httpx versions."""
+    network_error = getattr(httpx_module, "NetworkError", None)
+    if network_error is not None:
+        return (network_error,)
+
+    concrete_error_names = ("ConnectError", "ReadError", "WriteError", "CloseError")
+    concrete_errors = tuple(
+        getattr(httpx_module, name)
+        for name in concrete_error_names
+        if hasattr(httpx_module, name)
+    )
+    if concrete_errors:
+        return concrete_errors
+
+    transport_error = getattr(httpx_module, "TransportError", None)
+    if transport_error is not None:
+        return (transport_error,)
+
+    return (httpx_module.RequestError,)
+
+
+def httpx_transient_error_types(
+    httpx_module: Any = httpx,
+) -> Tuple[Type[BaseException], ...]:
+    return (*httpx_network_error_types(httpx_module), httpx_module.TimeoutException)
+
+
+def httpx_retry_error_types(
+    httpx_module: Any = httpx,
+) -> Tuple[Type[BaseException], ...]:
+    return (*httpx_transient_error_types(httpx_module), httpx_module.HTTPStatusError)

--- a/safety/httpx_compat.py
+++ b/safety/httpx_compat.py
@@ -3,6 +3,14 @@ from typing import Any, Tuple, Type
 import httpx
 
 
+def _httpx_exception_type(
+    httpx_module: Any,
+    name: str,
+) -> Tuple[Type[BaseException], ...]:
+    exception_type = getattr(httpx_module, name, None)
+    return (exception_type,) if exception_type is not None else ()
+
+
 def httpx_network_error_types(
     httpx_module: Any = httpx,
 ) -> Tuple[Type[BaseException], ...]:
@@ -24,16 +32,22 @@ def httpx_network_error_types(
     if transport_error is not None:
         return (transport_error,)
 
-    return (httpx_module.RequestError,)
+    return _httpx_exception_type(httpx_module, "RequestError")
 
 
 def httpx_transient_error_types(
     httpx_module: Any = httpx,
 ) -> Tuple[Type[BaseException], ...]:
-    return (*httpx_network_error_types(httpx_module), httpx_module.TimeoutException)
+    return (
+        *httpx_network_error_types(httpx_module),
+        *_httpx_exception_type(httpx_module, "TimeoutException"),
+    )
 
 
 def httpx_retry_error_types(
     httpx_module: Any = httpx,
 ) -> Tuple[Type[BaseException], ...]:
-    return (*httpx_transient_error_types(httpx_module), httpx_module.HTTPStatusError)
+    return (
+        *httpx_transient_error_types(httpx_module),
+        *_httpx_exception_type(httpx_module, "HTTPStatusError"),
+    )

--- a/tests/test_httpx_compat.py
+++ b/tests/test_httpx_compat.py
@@ -72,6 +72,15 @@ def test_httpx_network_error_types_falls_back_to_concrete_errors():
     )
 
 
+def test_httpx_network_error_types_omits_missing_request_error():
+    fake_httpx = SimpleNamespace(
+        TimeoutException=FakeTimeoutException,
+        HTTPStatusError=FakeHTTPStatusError,
+    )
+
+    assert httpx_network_error_types(fake_httpx) == ()
+
+
 def test_httpx_transient_error_types_include_timeout():
     fake_httpx = SimpleNamespace(
         ConnectError=FakeConnectError,
@@ -84,6 +93,15 @@ def test_httpx_transient_error_types_include_timeout():
         FakeConnectError,
         FakeTimeoutException,
     )
+
+
+def test_httpx_transient_error_types_handles_missing_request_error():
+    fake_httpx = SimpleNamespace(
+        TimeoutException=FakeTimeoutException,
+        HTTPStatusError=FakeHTTPStatusError,
+    )
+
+    assert httpx_transient_error_types(fake_httpx) == (FakeTimeoutException,)
 
 
 def test_httpx_retry_error_types_include_http_status_error():

--- a/tests/test_httpx_compat.py
+++ b/tests/test_httpx_compat.py
@@ -1,0 +1,108 @@
+from types import SimpleNamespace
+
+import httpx
+
+from safety.httpx_compat import (
+    httpx_network_error_types,
+    httpx_retry_error_types,
+    httpx_transient_error_types,
+)
+
+
+class FakeNetworkError(Exception):
+    pass
+
+
+class FakeConnectError(Exception):
+    pass
+
+
+class FakeReadError(Exception):
+    pass
+
+
+class FakeWriteError(Exception):
+    pass
+
+
+class FakeCloseError(Exception):
+    pass
+
+
+class FakeTimeoutException(Exception):
+    pass
+
+
+class FakeHTTPStatusError(Exception):
+    pass
+
+
+class FakeRequestError(Exception):
+    pass
+
+
+def test_httpx_network_error_types_prefers_network_error():
+    fake_httpx = SimpleNamespace(
+        NetworkError=FakeNetworkError,
+        ConnectError=FakeConnectError,
+        TimeoutException=FakeTimeoutException,
+        HTTPStatusError=FakeHTTPStatusError,
+        RequestError=FakeRequestError,
+    )
+
+    assert httpx_network_error_types(fake_httpx) == (FakeNetworkError,)
+
+
+def test_httpx_network_error_types_falls_back_to_concrete_errors():
+    fake_httpx = SimpleNamespace(
+        ConnectError=FakeConnectError,
+        ReadError=FakeReadError,
+        WriteError=FakeWriteError,
+        CloseError=FakeCloseError,
+        TimeoutException=FakeTimeoutException,
+        HTTPStatusError=FakeHTTPStatusError,
+        RequestError=FakeRequestError,
+    )
+
+    assert httpx_network_error_types(fake_httpx) == (
+        FakeConnectError,
+        FakeReadError,
+        FakeWriteError,
+        FakeCloseError,
+    )
+
+
+def test_httpx_transient_error_types_include_timeout():
+    fake_httpx = SimpleNamespace(
+        ConnectError=FakeConnectError,
+        TimeoutException=FakeTimeoutException,
+        HTTPStatusError=FakeHTTPStatusError,
+        RequestError=FakeRequestError,
+    )
+
+    assert httpx_transient_error_types(fake_httpx) == (
+        FakeConnectError,
+        FakeTimeoutException,
+    )
+
+
+def test_httpx_retry_error_types_include_http_status_error():
+    fake_httpx = SimpleNamespace(
+        ConnectError=FakeConnectError,
+        TimeoutException=FakeTimeoutException,
+        HTTPStatusError=FakeHTTPStatusError,
+        RequestError=FakeRequestError,
+    )
+
+    assert httpx_retry_error_types(fake_httpx) == (
+        FakeConnectError,
+        FakeTimeoutException,
+        FakeHTTPStatusError,
+    )
+
+
+def test_httpx_retry_error_types_works_with_installed_httpx():
+    retry_types = httpx_retry_error_types()
+
+    assert httpx.TimeoutException in retry_types
+    assert httpx.HTTPStatusError in retry_types


### PR DESCRIPTION
## Description

Fixes the import-time failure when Safety is used with httpx versions that no longer expose `httpx.NetworkError`.

The retry exception tuple now comes from a small compatibility helper that prefers `NetworkError` when available, then falls back to concrete network error classes (`ConnectError`, `ReadError`, `WriteError`, `CloseError`) before broader httpx bases. The enrollment transient-error wrapper uses the same helper so exception handling does not reintroduce the same missing-attribute failure.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## Related Issues

Fixes #860

## Testing

- [x] Tests added or updated
- [ ] No tests required

Not run locally.

## Checklist

- [x] Code is well-documented
- [ ] Changelog is updated (if needed)
- [x] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes

Opened as draft so maintainers can decide whether this is the preferred compatibility boundary for httpx 1.0 pre-releases.