### PR TITLE
fix: support SFTY-format vulnerability IDs in policy files

### DIFF
--- a/safety/util.py
+++ b/safety/util.py
@@ -12,13 +12,12 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple, U
 import click
 from click import BadParameter
 from dparse import filetypes, parse
+from httpx import URL
 from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
 from packaging.version import parse as parse_version
-from httpx import URL
 from ruamel.yaml import YAML
 from ruamel.yaml.error import MarkedYAMLError
-from safety.meta import get_version
 from safety_schemas.models import TelemetryModel
 
 from safety.constants import (
@@ -28,6 +27,7 @@ from safety.constants import (
 )
 from safety.errors import InvalidProvidedReportError
 from safety.events.event_bus import start_event_bus
+from safety.meta import get_version
 from safety.models import (
     Package,
     RequirementFile,
@@ -35,13 +35,12 @@ from safety.models import (
     is_pinned_requirement,
 )
 
-
 if TYPE_CHECKING:
+    import typer
+
+    from safety.auth.models import Auth
     from safety.cli_util import CustomContext
     from safety.models import SafetyCLI
-    from safety.auth.models import Auth
-
-    import typer
 
 
 LOG = logging.getLogger(__name__)
@@ -1078,14 +1077,22 @@ class SafetyPolicyFile(click.ParamType):
                     expires = ignored_vuln_config.get("expires", "")
                     expires = str(expires) if expires else None
 
+                    vuln_id_str = str(ignored_vuln_id)
+                    is_valid_id = False
+
                     try:
-                        if int(ignored_vuln_id) < 0:
-                            raise ValueError("Negative Vulnerability ID")
+                        is_valid_id = int(vuln_id_str) > 0
                     except ValueError:
+                        pass
+                    if not is_valid_id:
+                        is_valid_id = bool(re.match(r"^SFTY-\d{8}-\d+$", vuln_id_str))
+                    if not is_valid_id:
                         self.fail(
                             msg.format(
-                                hint=f"vulnerability id {ignored_vuln_id} under the 'ignore-vulnerabilities' root needs to "
-                                f"be a positive integer"
+                                hint=(
+                                    f"vulnerability id {ignored_vuln_id} under the 'ignore-vulnerabilities' root needs to "
+                                    + "be a positive integer or a valid SFTY ID (e.g., SFTY-20260218-01424)"
+                                )
                             )
                         )
 
@@ -1468,9 +1475,9 @@ def initialize_event_bus(ctx: Union["CustomContext", "typer.Context"]) -> bool:
                 if event_bus := obj.event_bus:
                     # Trigger here CLI GROUP LOADED event
                     from safety.events.utils import (
-                        create_internal_event,
                         InternalEventType,
                         InternalPayload,
+                        create_internal_event,
                     )
 
                     event = create_internal_event(

--- a/tests/.policy_with_ignores.yml
+++ b/tests/.policy_with_ignores.yml
@@ -1,10 +1,12 @@
 security:
-    ignore-vulnerabilities:
-        44423:
-            reason: we don't use the vulnerable function
-            expires: '2022-01-21'
-        44741:
-            reason: This is a low severity vuln, we can ignore
-            expires: '2022-02-22 14:00:00'
-        35797:
-        23231:
+  ignore-vulnerabilities:
+    44423:
+      reason: we don't use the vulnerable function
+      expires: "2022-01-21"
+    44741:
+      reason: This is a low severity vuln, we can ignore
+      expires: "2022-02-22 14:00:00"
+    35797:
+    23231:
+    SFTY-20260218-01424:
+      reason: Fixed nltk version 3.9.3 requires Python>=3.10

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,16 +3,16 @@ import os
 import sys
 import unittest
 from io import StringIO
-from unittest.mock import MagicMock, patch, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 import click as click
 
 from safety import util
 from safety.models import SafetyRequirement
 from safety.util import (
-    read_requirements,
-    get_processed_options,
     SafetyPolicyFile,
+    get_processed_options,
+    read_requirements,
     transform_ignore,
 )
 
@@ -136,6 +136,24 @@ class ReadRequirementsTestCase(unittest.TestCase):
         )
 
         self.assertEqual(ignore, cli_ignores)
+
+    @patch.object(
+        click,
+        "get_current_context",
+        Mock(
+            get_parameter_source=Mock(return_value=click.core.ParameterSource.DEFAULT)
+        ),
+    )
+    def test_policy_file_accepts_sfty_vulnerability_ids(self):
+        path_pf = os.path.join(self.dirname, ".policy_with_ignores.yml")
+        policy_file = SafetyPolicyFile().convert(value=path_pf, param=None, ctx=None)
+
+        ignore = policy_file.get("security", {}).get("ignore-vulnerabilities", {})
+        self.assertIn("SFTY-20260218-01424", ignore)
+        self.assertEqual(
+            ignore["SFTY-20260218-01424"]["reason"],
+            "Fixed nltk version 3.9.3 requires Python>=3.10",
+        )
 
     @patch.object(
         click,


### PR DESCRIPTION
## Summary
- Policy file validation now accepts both legacy numeric IDs (e.g., `44423`) and the new SFTY format (e.g., `SFTY-20260218-01424`)
- Updated error hint to mention both accepted formats

## Test plan
- [x] Existing tests pass (numeric IDs still work)
- [x] New test with SFTY-format ID in policy file loads without error
- [x] Invalid IDs (negative, random strings) are still rejected

Fixes #847