### PR TITLE
Replace deprecated httpx.NetworkError with httpx.ConnectError

### DIFF
--- a/safety/auth/enrollment.py
+++ b/safety/auth/enrollment.py
@@ -27,7 +27,7 @@ def call_enrollment_endpoint(
 ) -> dict:
     """Public wrapper — delegates to platform_client.enroll().
 
-    Catches transient network errors (httpx.NetworkError, httpx.TimeoutException)
+    Catches transient network errors (httpx.ConnectError, httpx.TimeoutException)
     that tenacity re-raises after retry exhaustion and wraps them in
     EnrollmentTransientFailure (exit code 75) so MDM orchestrators can
     distinguish retryable failures from permanent ones.
@@ -60,7 +60,7 @@ def call_enrollment_endpoint(
     # Broader than @retry's types: also wraps ReadError/WriteError/CloseError
     # (transient, but not retried) as exit-code 75 for MDM orchestrators.
     # Excludes ProtocolError / UnsupportedProtocol (non-transient config bugs).
-    except (httpx.NetworkError, httpx.TimeoutException) as exc:
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
         raise EnrollmentTransientFailure(
             f"Enrollment failed after retries: {exc}"
         ) from exc

--- a/safety/events/handlers/common.py
+++ b/safety/events/handlers/common.py
@@ -168,7 +168,7 @@ class SecurityEventsHandler(EventHandler[SecurityEventTypes]):
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=0.1, min=0.2, max=1.0),
         retry=retry_if_exception_type(
-            (httpx.NetworkError, httpx.TimeoutException, httpx.HTTPStatusError)
+            (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError)
         ),
         before_sleep=before_sleep_log(logging.getLogger("api_client"), logging.WARNING),
     )


### PR DESCRIPTION
httpx.NetworkError was removed in httpx 1.0. The replacement is httpx.ConnectError, which was introduced in httpx 0.24 and has been the standard connection error class since.

Affected files:
- safety/auth/enrollment.py
- safety/events/handlers/common.py

Closes #860