### PR TITLE
fix: gracefully handle invalid specifiers in vulnerability DB (#873)

### DIFF
--- a/safety/scan/ecosystems/python/main.py
+++ b/safety/scan/ecosystems/python/main.py
@@ -38,7 +38,7 @@ from ..base import InspectableFile, Remediable
 
 from packaging.version import parse as parse_version
 from packaging.utils import canonicalize_name
-from packaging.specifiers import SpecifierSet
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
 
 
 LOG = logging.getLogger(__name__)
@@ -338,7 +338,14 @@ class PythonFile(InspectableFile, Remediable):
             if name in vulnerable_packages:
                 # we have a candidate here, build the spec set
                 for specifier in db["vulnerable_packages"][name]:
-                    spec_set = SpecifierSet(specifiers=specifier)
+                    try:
+                        spec_set = SpecifierSet(specifiers=specifier)
+                    except InvalidSpecifier:
+                        LOG.warning(
+                            "Skipping invalid specifier '%s' for package '%s'",
+                            specifier, name
+                        )
+                        continue
 
                     if spec.is_vulnerable(spec_set, dependency.insecure_versions):
                         if not db_full:


### PR DESCRIPTION
## Description

When the vulnerability database contains an invalid version specifier (e.g., `=2.7.0` instead of `==2.7.0`), safety crashes with an unhandled `InvalidSpecifier` exception and no useful error message.

## Reproduction

Run `safety check` against an environment that includes `tensorflow`. The vulnerability DB entry for tensorflow contains the specifier `=2.7.0` (single equals), which `packaging.specifiers.SpecifierSet` rejects.

## Expected vs Actual

- **Expected**: Safety skips the invalid entry with a warning and continues scanning
- **Actual**: Unhandled exception: `Invalid specifier: '=2.7.0'` with no traceback or useful info

## Fix

Wrap the `SpecifierSet()` call in a try-except to catch `InvalidSpecifier`, log a warning, and skip the offending entry.

## Testing

- [x] Invalid specifiers are now logged as warnings instead of crashing
- [x] Normal specifiers continue to work as before

Fixes #873