### PR TITLE
fix(scan): skip invalid package specifiers instead of crashing

### DIFF
--- a/safety/scan/ecosystems/python/main.py
+++ b/safety/scan/ecosystems/python/main.py
@@ -38,7 +38,7 @@ from ..base import InspectableFile, Remediable
 
 from packaging.version import parse as parse_version
 from packaging.utils import canonicalize_name
-from packaging.specifiers import SpecifierSet
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
 
 
 LOG = logging.getLogger(__name__)
@@ -338,7 +338,15 @@ class PythonFile(InspectableFile, Remediable):
             if name in vulnerable_packages:
                 # we have a candidate here, build the spec set
                 for specifier in db["vulnerable_packages"][name]:
-                    spec_set = SpecifierSet(specifiers=specifier)
+                    try:
+                        spec_set = SpecifierSet(specifiers=specifier)
+                    except InvalidSpecifier:
+                        LOG.warning(
+                            "Skipping invalid specifier '%s' for package '%s'.",
+                            specifier,
+                            name,
+                        )
+                        continue
 
                     if spec.is_vulnerable(spec_set, dependency.insecure_versions):
                         if not db_full:


### PR DESCRIPTION
## Summary

Running `safety scan` against an environment with `tensorflow` causes an unhandled crash:

> Unhandled exception happened: Invalid specifier: '=2.7.0'

The tensorflow vulnerability database entry contains the invalid specifier string `"=2.7.0"` (single equals sign), which is not a valid PEP 440 specifier. The `SpecifierSet()` parser from `packaging.specifiers` raises `InvalidSpecifier`, and the exception propagates unhandled.

### Reproduction

Install tensorflow and run `safety scan`:

```
$ pip install tensorflow
$ safety scan
```

Expected: the scan completes, reporting known vulnerabilities.
Actual: `Unhandled exception happened: Invalid specifier: '=2.7.0'`

### Fix

Wrap the `SpecifierSet()` call in `safety/scan/ecosystems/python/main.py` in a try/except to catch `InvalidSpecifier`, skip the invalid entry, and log a warning. This allows the scan to continue processing the remaining valid specifiers.

Fixes #873