### PR TITLE
docs: fix development setup instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,16 +74,18 @@ Please read and adhere to our [Code of Conduct](CODE_OF_CONDUCT.md) to ensure a 
    git clone https://github.com/pyupio/safety.git
    ```
 
-2. **Set up your environment:**
-- Ensure you are using Python 3.11.2.
-- Install dependencies:
+2. 2. **Set up your environment:**
+- Ensure you are using Python 3.9 or later.
+- Install the project in editable mode with development dependencies:
     ```bash
-    pip install -r requirements.txt
+    pip install -e ".[dev]"
     ```
 
 ### Running Tests
 We use pytest for running tests. To run the tests locally:
-    ```pytest```
+        ```bash
+    pytest
+    ```
 
 Ensure all tests pass before submitting your changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,17 +74,18 @@ Please read and adhere to our [Code of Conduct](CODE_OF_CONDUCT.md) to ensure a 
    git clone https://github.com/pyupio/safety.git
    ```
 
-2. 2. **Set up your environment:**
+2. **Set up your environment using Hatch:**
 - Ensure you are using Python 3.9 or later.
-- Install the project in editable mode with development dependencies:
+- Install Hatch and create the development environment:
     ```bash
-    pip install -e ".[dev]"
+    pip install hatch
+    hatch shell
     ```
 
 ### Running Tests
 We use pytest for running tests. To run the tests locally:
         ```bash
-    pytest
+    hatch run test
     ```
 
 Ensure all tests pass before submitting your changes.


### PR DESCRIPTION

Fixed the development setup instructions in CONTRIBUTING.md.

Changes made:

* Updated Python version guidance to reflect supported versions (Python 3.9+)
* Replaced the outdated `pip install -r requirements.txt` command with `pip install -e ".[dev]"`
* Improved the test-running instructions and formatting

Ref #572
