### PR TITLE
fix: sanitize Pipfile.lock to prevent upstream dparse KeyError (Issue…

### DIFF
--- a/safety/scan/ecosystems/python/dependencies.py
+++ b/safety/scan/ecosystems/python/dependencies.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from pathlib import Path
+import json
 import sys
 from typing import Generator, List, Optional
 
@@ -225,6 +226,28 @@ def read_dependencies(
     found = absolute_path
 
     content = fh.read()
+    #solution for error "Unhandled exception happened:'hashes' in issue 849
+    if path and path.endswith("Pipfile.lock"):
+            try:
+                # content comes as a string, it gets parsed into json format and converted into a dictionary
+                data = json.loads(content)
+                modified = False
+                
+                # Pipfile.lock groups dependencies as "deafault" and "develop"
+                for section in ["default", "develop"]:
+                    if section in data:
+                        for pkg_name, pkg_meta in data[section].items():
+                            # if it is a pkg dictonary and has no hashes, it gets blinded/blocked
+                            if isinstance(pkg_meta, dict) and "hashes" not in pkg_meta:
+                                pkg_meta["hashes"] = []
+                                modified = True
+                
+                # if changes were made, it gets converted back to a string
+                if modified:
+                    content = json.dumps(data)
+            except Exception:
+                # if the file is not a JSON for any reason, it silently fails and dparse handles the error
+                pass
     dependency_file = parse(content, path=path, resolve=resolve)
 
     reqs_pkg = defaultdict(list)


### PR DESCRIPTION
… 849)

## Description
Fixes #849. 

This PR addresses a bug where running a scan on a `Pipfile.lock` causes an unhandled `KeyError: 'hashes'` exception, aborting the entire scan process. 

### Root Cause Analysis
After tracing the unhandled exception, it was discovered that the bug originates in the upstream `dparse` library (`dparse.parser`). `dparse` assumes that every dependency object in a `Pipfile.lock` contains a `"hashes"` key. If even a single dependency lacks this key (which can happen with certain local or legacy package installations), `dparse` throws a `KeyError` and fails.

### Solution
Since we cannot directly modify the upstream `dparse` library in the user's environment, this PR introduces a defensive middleware approach within Safety's `process_files` pipeline. 

In `safety/scan/ecosystems/python/dependencies.py`:
- We intercept the file content before it is passed to `dparse`.
- If the file is strictly named `Pipfile.lock`, we parse the JSON and iterate through the `default` and `develop` sections.
- If any package is missing the `"hashes"` key, we inject an empty list (`"hashes": []`).
- This satisfies `dparse`'s strict requirement, allowing the parser to successfully extract the dependency names and versions without crashing.
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

## Related Issues

<!-- List any related issues or reference other PRs, if applicable. Example: Fixes #123, Closes #456 -->

## Testing

- [ ] Tests added or updated
- [x] No tests required
Although tests were checked before commiting to ensure that everything works as it should

## Checklist

- [x] Code is well-documented
- [ ] Changelog is updated (if needed)
- [x] No sensitive information (e.g., keys, credentials) is included in the code
- [x] All PR feedback is addressed

## Additional Notes

**Scope limitation:** The sanitization logic is strictly gated behind `if path.endswith("Pipfile.lock"):` to ensure we do not accidentally attempt to parse `requirements.txt` (plain text) or `poetry.lock` (TOML) as JSON, preventing any unintended side effects.