### PR TITLE
enhance: improve error messages with contextual details (closes #577)

### DIFF
--- a/safety/auth/server.py
+++ b/safety/auth/server.py
@@ -112,7 +112,7 @@ def auth_process(
         return platform.fetch_user_info()
 
     except Exception as e:
-        LOG.exception(e)
+        LOG.exception("Authentication failed unexpectedly: %s", e)
         sys.exit(1)
 
 

--- a/safety/codebase_utils.py
+++ b/safety/codebase_utils.py
@@ -83,7 +83,7 @@ def save_project_info(project: ProjectModel, project_path: Path) -> bool:
         with open(project_path, "w") as configfile:
             config.write(configfile)
     except Exception:
-        logger.exception("Error saving project info")
+        logger.exception("Error saving project info to %s", project_path)
         return False
 
     return True

--- a/safety/encoding.py
+++ b/safety/encoding.py
@@ -24,5 +24,5 @@ def detect_encoding(file_path: Path) -> str:
 
         return "utf-8"
     except Exception:
-        logger.exception("Error detecting encoding")
+        logger.exception("Error detecting encoding for file %s, falling back to utf-8", file_path)
         return "utf-8"

--- a/safety/init/main.py
+++ b/safety/init/main.py
@@ -359,7 +359,7 @@ def launch_auth_if_needed(ctx: "SafetyContext", console: Console) -> Optional[st
         data = auth.platform.initialize()  # type: ignore
         org_slug = data.get("organization-data", {}).get("slug")
     except Exception:
-        logger.exception("Unable to load data on the init command")
+        logger.exception("Unable to load organization data during init. Check your authentication and network connectivity.")
 
     return org_slug
 

--- a/safety/scan/ecosystems/target.py
+++ b/safety/scan/ecosystems/target.py
@@ -45,7 +45,7 @@ class InspectableFileContext:
                 file_type=self.file_type, file=file
             )
         except Exception:
-            logger.exception("Error opening file")
+            logger.exception("Error opening file %s for scanning", self.file_path)
 
         return self.inspectable_file
 


### PR DESCRIPTION
## Summary

Addresses #577 by improving five vague exception log messages that previously gave no context about *what* failed or *where*.

### Changes

| File | Before | After |
|------|--------|-------|
| `auth/server.py` | `LOG.exception(e)` | `LOG.exception("Authentication failed unexpectedly: %s", e)` |
| `encoding.py` | `"Error detecting encoding"` | `"Error detecting encoding for file %s, falling back to utf-8"` |
| `codebase_utils.py` | `"Error saving project info"` | `"Error saving project info to %s"` |
| `scan/ecosystems/target.py` | `"Error opening file"` | `"Error opening file %s for scanning"` |
| `init/main.py` | `"Unable to load data on the init command"` | `"Unable to load organization data during init. Check your authentication and network connectivity."` |

### Why this matters

- File paths in log messages make it immediately obvious *which* file caused the error without needing to add debug prints or re-run with verbose flags.
- The `auth/server.py` fix replaces a bare `LOG.exception(e)` (which duplicates the exception object as the message) with a proper descriptive string.
- The `init/main.py` message now includes an actionable hint for the most common root causes (auth/network).