### PR TITLE
docs: fix typographical errors across codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,7 +296,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Package version upgrade for psutil and filelock (#652)
 - Package version upgrade for typer (#654)
 - Package version upgrade for pydantic (#655)
-- Add "--use-server-matching" arguement (#640)
+- Add "--use-server-matching" argument (#640)
 - Bugfix for safety "NoneType is not iterable" error (#657)
 
 

--- a/safety/alerts/requirements.py
+++ b/safety/alerts/requirements.py
@@ -361,7 +361,7 @@ class Requirement(object):
         """
         semver = {"major": 0, "minor": 0, "patch": 0}
         version_parts = version.split(".")
-        # don't be overly clever here. repitition makes it more readable and works exactly how
+        # don't be overly clever here. repetition makes it more readable and works exactly how
         # it is supposed to
         try:
             semver["major"] = int(version_parts[0])

--- a/safety/scan/ecosystems/base.py
+++ b/safety/scan/ecosystems/base.py
@@ -8,7 +8,7 @@ from safety_schemas.models import (
 )
 from typer import FileTextWrite
 
-NOT_IMPLEMENTED = "Not implemented funtion"
+NOT_IMPLEMENTED = "Not implemented function"
 
 
 class Inspectable(ABC):

--- a/safety/tool/uv/command.py
+++ b/safety/tool/uv/command.py
@@ -106,7 +106,7 @@ class AuditableUvCommand(UvCommand, InstallationAuditMixin):
             {
                 # Default index URL
                 # When the package manager is wrapped, we provide a default index so the search always falls back to the Safety index
-                # UV_INDEX_URL is deprecated by UV, we comment it out to avoid a anoying warning, UV_DEFAULT_INDEX is available since uv 0.4.23
+                # UV_INDEX_URL is deprecated by UV, we comment it out to avoid an annoying warning, UV_DEFAULT_INDEX is available since uv 0.4.23
                 # So we decided to support only UV_DEFAULT_INDEX, as we don't inject the uv version in the command pipeline yet.
                 #
                 # "UV_INDEX_URL": default_index_url,

--- a/tests/test_db/insecure_full.json
+++ b/tests/test_db/insecure_full.json
@@ -22,7 +22,7 @@
                 "specs": [
                     "<1.9"
                 ],
-                "advisory": "Some adivsory",
+                "advisory": "Some advisory",
                 "transitive": false,
                 "more_info_path": "/v/42108/97c",
                 "ids": [
@@ -34,13 +34,13 @@
                         "type": "cve",
                         "id": "some cve"
                     }
-                ]                
+                ]
             },
             {
                 "specs": [
                     "<1.9"
                 ],
-                "advisory": "Some other adivsory",
+                "advisory": "Some other advisory",
                 "transitive": false,
                 "more_info_path": "/v/42108/97c",
                 "ids": [


### PR DESCRIPTION
Fixes typographical errors found across the codebase:

- CHANGELOG.md: rguement ? rgument
- safety/alerts/requirements.py: epitition ? epetition
- safety/scan/ecosystems/base.py: untion ? unction
- safety/tool/uv/command.py: noying ? nnoying
- tests/test_db/insecure_full.json: divsory ? dvisory (x2)

Fixes #574