### PR TITLE
enhance(logging): improve feature flags configuration save error message

### DIFF
--- a/safety/auth/utils.py
+++ b/safety/auth/utils.py
@@ -119,7 +119,12 @@ def save_flags_config(flags: Dict[FeatureType, bool]) -> None:
         with open(CONFIG_FILE_USER, "w") as config_file:
             config.write(config_file)
     except Exception:
-        LOG.exception("Unable to save flags configuration.")
+        LOG.exception(
+            "Unable to save feature flags configuration to %s. "
+            "The application will continue using existing configuration "
+            "or default flag values until the next restart.",
+            CONFIG_FILE_USER,
+        )
 
 
 def get_feature_name(feature: FeatureType, as_attr: bool = False) -> str:


### PR DESCRIPTION
## Description

Improves the error message emitted when saving feature flag configuration fails.

Previously the log message only reported:

`Unable to save flags configuration.`

This change adds:
- the path of the configuration file that failed to save
- clarification that Safety will continue using existing or default flag values until restart
- additional context to help users understand the impact of the failure

Related to #577.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [x] Other (logging/error message improvement)

## Testing

- [x] No tests required

This change only modifies the log message text and does not affect application behavior.

## Checklist

- [x] My code follows the project's style guidelines.
- [x] I have reviewed my changes.
- [x] I have tested the change locally where applicable.