### PR TITLE
enhance(logging): improve cloud policy download error message

### DIFF
--- a/safety/scan/render.py
+++ b/safety/scan/render.py
@@ -399,9 +399,12 @@ def print_wait_policy_download(
         try:
             f, kwargs = closure
             policy = f(**kwargs)
-        except Exception as e:
-            LOG.exception(f"Policy download failed, reason: {e}")
-            console.print("Not using cloud policy file.")
+        except Exception:
+            LOG.exception("Failed to download policy from Safety Platform.")
+            console.print(
+                "[yellow]Unable to download cloud policy from Safety Platform. "
+                "Continuing the scan without cloud policy configuration.[/yellow]"
+            )
 
         if policy:
             wait_msg = "Policy fetched from Safety Platform."


### PR DESCRIPTION
## Description

Improves the user-facing and logged error messages shown when cloud policy download fails.

Previously, the code:

- logged the exception message redundantly using `LOG.exception(..., reason: {e})`
- displayed the generic message:

`Not using cloud policy file.`

This change:

- removes duplicate exception information from the log output
- provides a clearer log message indicating that the download from Safety Platform failed
- improves the console message to explain that the scan will continue without cloud policy configuration

This helps users better understand both the failure and the fallback behavior.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (logging/error message improvement)

## Related Issues

Related to #577

## Testing

- [ ] Tests added or updated
- [x] No tests required

This change only modifies log and console output and does not alter application behavior.

## Checklist

- [x] My code follows the project's style guidelines.
- [x] I have reviewed my changes.
- [x] I have tested the change locally where applicable.