### PR TITLE
docs: fix broken GitHub Action link in Resources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,6 @@ We maintain a policy of supporting all maintained and secure versions of Python,
 - [Documentation](https://docs.safetycli.com)
 - [Careers/Hiring](https://apply.workable.com/safety/)
 - [Security Research and Blog](https://safetycli.com/blog)
-- [GitHub Action](https://github.com/safetycli/action)
+- [GitHub Action](https://github.com/pyupio/safety-action)
 - [Support](mailto:support@safetycli.com)
 - [Status Page](https://status.safetycli.com)


### PR DESCRIPTION
The "Resources" section links to https://github.com/safetycli/action, which returns a 404. 
The correct, active repo is https://github.com/pyupio/safety-action, which is already linked 
correctly elsewhere in the README (under "Getting Started > GitHub Action").

Refs #572