### PR TITLE
Fixed typos in files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,7 +296,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Package version upgrade for psutil and filelock (#652)
 - Package version upgrade for typer (#654)
 - Package version upgrade for pydantic (#655)
-- Add "--use-server-matching" arguement (#640)
+- Add "--use-server-matching" argument (#640)
 - Bugfix for safety "NoneType is not iterable" error (#657)
 
 

--- a/safety/safety.py
+++ b/safety/safety.py
@@ -107,7 +107,7 @@ def get_from_cache(
         skip_time_verification (bool): Whether to skip time verification.
 
     Returns:
-        Optional[[Dict[str, Any]]: The cached database if available and valid, otherwise False.
+        Optional[Dict[str, Any]: The cached database if available and valid, otherwise False.
     """
     cache_file_lock = f"{DB_CACHE_FILE}.lock"
     os.makedirs(os.path.dirname(cache_file_lock), exist_ok=True)

--- a/safety/scan/ecosystems/base.py
+++ b/safety/scan/ecosystems/base.py
@@ -8,7 +8,7 @@ from safety_schemas.models import (
 )
 from typer import FileTextWrite
 
-NOT_IMPLEMENTED = "Not implemented funtion"
+NOT_IMPLEMENTED = "Not implemented function"
 
 
 class Inspectable(ABC):


### PR DESCRIPTION
## Description
Fixed a few typos found in error messages, docstrings, and the changelog:
- Corrected "funtion" to "function" in the NOT_IMPLEMENTED error message in `safety/scan/ecosystems/base.py`
- Fixed a stray extra bracket in the docstring type annotation in `safety/safety.py` (`Optional[[Dict...` → `Optional[Dict...`)
- Corrected "arguement" to "argument" in `CHANGELOG.md`

## Type of Change
- [x] Documentation update

## Related Issues
Fixes #574

## Testing
- [x] No tests required

## Checklist
- [x] Code is well-documented
- [x] Changelog is updated (if needed)
- [x] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes
This is my first open source contribution and I am happy to make any adjustments if the maintainers prefer a different approach.