### PR TITLE
chore(deps): bump safety-schemas 0.0.16 → 0.0.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "certifi",
   "tenacity>=8.1.0",
   "ruamel.yaml>=0.17.21",
-  "safety-schemas==0.0.16",
+  "safety-schemas==0.0.19",
   "typer>=0.16.0,<0.26.0",
   "typing-extensions>=4.7.1",
   "nltk>=3.9",


### PR DESCRIPTION
## Summary

Bumps the pinned `safety-schemas` dependency from `0.0.16` to `0.0.19`.

`0.0.19` emits timezone-aware UTC scan timestamps (`MetadataModel.timestamp` now defaults via `default_factory` returning `datetime.now(timezone.utc)` instead of a bare, timezone-naive `datetime.now()`). Both fresh-emit sites in this repo — the scan decorator and `init_scan` — construct `MetadataModel` without passing `timestamp`, so they rely on that default; picking up `0.0.19` is what makes the CLI emit unambiguous UTC, which stops scan ingest from misreading naive stamps as UTC.

API surface across `0.0.16 → 0.0.19` is additive only (new `PackageEcosystem` / `InstallationAction` exports and installation config models); nothing this CLI imports was removed or renamed, and the `models.events` subpackage it depends on is unchanged.

**Draft — do not merge until `safety-schemas==0.0.19` is published to PyPI** (`pyupio/safety_schemas#43` bumps the version; the tag/build/publish is a manual step after that merges). CI here will fail to resolve the dependency until then.