### PR TITLE
fix(alerts): bound changelog upgrade range by target version

### DIFF
--- a/safety/alerts/utils.py
+++ b/safety/alerts/utils.py
@@ -322,7 +322,9 @@ def fetch_changelog(
                     and from_spec.contains(parsed_version)
                 )
 
-                if version_check or spec_check and parsed_version <= to_version_parsed:
+                if (
+                    version_check or spec_check
+                ) and parsed_version <= to_version_parsed:
                     changelog[version] = log
 
     return changelog

--- a/tests/alerts/test_utils.py
+++ b/tests/alerts/test_utils.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import MagicMock, patch
 
 from safety.alerts import utils
 from tests.test_cli import get_vulnerability
@@ -147,3 +148,27 @@ class TestUtils(unittest.TestCase):
         score = 11.0
         expected_label = None
         self.assertEqual(utils.cvss3_score_to_label(score), expected_label)
+
+    @patch("safety.alerts.utils.httpx.get")
+    def test_fetch_changelog_bounds_upgrade_range_by_target_version(self, mock_get):
+        # Changelog spanning below, within, and above the requested range.
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "0.4": "too old",
+            "1.2.1": "in range",
+            "1.3": "in range (target)",
+            "2.0": "beyond target",
+        }
+        mock_get.return_value = response
+
+        changelog = utils.fetch_changelog(
+            "requests",
+            from_version="1.2",
+            to_version="1.3",
+            api_key=self.api_key,
+        )
+
+        # Only releases in (1.2, 1.3] should be included: 2.0 is past the
+        # target version and 0.4 is before the starting version.
+        self.assertEqual(set(changelog), {"1.2.1", "1.3"})


### PR DESCRIPTION
## Summary

`fetch_changelog` is meant to collect only the releases within an upgrade range (per its own comment: *"update from 1.2 to 1.3 includes a changelog for 1.2.1 but not for 0.4"*). The filter has an operator-precedence bug:

```python
if version_check or spec_check and parsed_version <= to_version_parsed:
```

Since `and` binds tighter than `or`, this parses as:

```python
if version_check or (spec_check and parsed_version <= to_version_parsed):
```

so the `parsed_version <= to_version_parsed` upper bound only guards the `spec_check` branch. When `from_version` is set, `version_check` is true for **every** release newer than `from_version`, so releases past the target `to_version` are wrongly included.

Reproduction (`from=1.2`, `to=1.3`, releases `0.4/1.2.1/1.3/2.0`):
- before: `['2.0', '1.3', '1.2.1']` — `2.0` is beyond the target
- after: `['1.3', '1.2.1']` ✅

## Fix

Parenthesize so the target-version bound applies to both branches:

```python
if (version_check or spec_check) and parsed_version <= to_version_parsed:
```

`to_version` is a required argument (always parsed), so the bound is always defined; when `from_version` is `None`, `version_check` is falsy and behavior is unchanged.

## Test

Added `test_fetch_changelog_bounds_upgrade_range_by_target_version` (mocks `httpx.get`). It **fails on the current code** and passes after the fix; `tests/alerts/test_utils.py` stays green (14 passed).