### PR TITLE
fix(check): skip invalid specifiers from the vulnerability DB

### DIFF
--- a/safety/safety.py
+++ b/safety/safety.py
@@ -15,7 +15,7 @@ from typing import Dict, Optional, List, Any, Union, Iterator
 
 from authlib.integrations.base_client.errors import OAuthError
 import httpx
-from packaging.specifiers import SpecifierSet
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.utils import canonicalize_name
 from packaging.version import parse as parse_version, Version
 from pydantic_core import to_jsonable_python
@@ -753,7 +753,15 @@ def check(
         if name in vulnerable_packages:
             # we have a candidate here, build the spec set
             for specifier in db["vulnerable_packages"][name]:
-                spec_set = SpecifierSet(specifiers=specifier)
+                try:
+                    spec_set = SpecifierSet(specifiers=specifier)
+                except InvalidSpecifier:
+                    LOG.warning(
+                        "Skipping invalid specifier '%s' for package '%s'",
+                        specifier,
+                        name,
+                    )
+                    continue
 
                 if is_vulnerable(spec_set, req, pkg):
                     if not db_full:

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -225,6 +225,57 @@ class TestSafety(unittest.TestCase):
         self.assertEqual(len(vulns), 1)
 
     @patch("safety.safety.fetch_database_url")
+    def test_check_invalid_specifier_in_db(self, mock_fetch_db):
+        # A vulnerability DB entry with a malformed specifier such as
+        # "=1.7.0" (single equals) must be skipped instead of crashing.
+        insecure_path = os.path.join(self.dirname, "test_db", "insecure.json")
+        insecure_full_path = os.path.join(self.dirname, "test_db", "insecure_full.json")
+
+        with open(insecure_path) as f:
+            insecure_db = json.load(f)
+        with open(insecure_full_path) as f:
+            insecure_full_db = json.load(f)
+
+        insecure_db["vulnerable_packages"]["insecure-package"] = ["=1.7.0", "<1.0"]
+        insecure_full_db["vulnerable_packages"]["insecure-package"] = [
+            {
+                "specs": ["<1.0"],
+                "advisory": "Test advisory for insecure-package",
+                "transitive": False,
+                "more_info_path": "/v/test/path",
+                "ids": [{"type": "pyup", "id": "test-id"}],
+            }
+        ]
+
+        def mock_fetch_side_effect(*args, **kwargs):
+            db_name = kwargs.get(
+                "db_name", args[2] if len(args) > 2 else "insecure.json"
+            )
+            if db_name == "insecure_full.json":
+                return insecure_full_db
+            else:
+                return insecure_db
+
+        mock_fetch_db.side_effect = mock_fetch_side_effect
+
+        reqs = StringIO("insecure-package==0.1")
+        packages = read_requirements(reqs)
+
+        vulns, _ = check(
+            auth=self.auth,
+            packages=packages,
+            db_mirror=False,
+            cached=0,
+            ignore_vulns={},
+            ignore_severity_rules=None,
+            proxy={},
+            telemetry=False,
+        )
+
+        # The valid "<1.0" specifier is still matched.
+        self.assertEqual(len(vulns), 1)
+
+    @patch("safety.safety.fetch_database_url")
     def test_check_cached(self, mock_fetch_db):
         from safety.constants import DB_CACHE_FILE
 


### PR DESCRIPTION
## Description

`safety check` aborts with `Unhandled exception happened: Invalid specifier: '=1.7.0'` when the vulnerability DB contains a malformed specifier (single `=`, invalid per PEP 440). `check()` in `safety/safety.py` built a `SpecifierSet` directly from each DB entry with no guard, so one bad entry killed the whole run.

Invalid specifiers are now logged and skipped; remaining valid specifiers for the same package are still evaluated. This mirrors the guard proposed for the `scan` path in #879/#880, which left this `check` call site unpatched.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## Related Issues

Closes #882

## Testing

- [x] Tests added or updated
- [ ] No tests required

`tests/test_safety.py::TestSafety::test_check_invalid_specifier_in_db` feeds `["=1.7.0", "<1.0"]` for a package. It fails on `main` with `packaging.specifiers.InvalidSpecifier: Invalid specifier: '=1.7.0'` and passes with this change, still reporting the vulnerability matched by the valid `<1.0` specifier. Full `tests/test_safety.py`: 34 passed.

## Checklist

- [x] Code is well-documented
- [ ] Changelog is updated (if needed)
- [x] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes

Only the `check` code path is touched here. Note that the underlying `authlib` DB entry itself should still be corrected upstream (`=1.7.0` -> `==1.7.0`); this change only stops a bad entry from crashing the client.
