### PR TITLE
refactor(scan): deduplicate insecure_full.json loading

### DIFF
--- a/safety/scan/ecosystems/python/main.py
+++ b/safety/scan/ecosystems/python/main.py
@@ -277,6 +277,22 @@ class PythonFile(InspectableFile, Remediable):
         self.ecosystem = file_type.ecosystem
         self.file_type = file_type
 
+    def _load_full_db(self) -> dict | None:
+        """
+        Lazily loads the full vulnerability database from the local cache.
+
+        Returns:
+            dict | None: The full database, or None if unavailable or invalid.
+        """
+        db_full = get_from_cache(
+            db_name="insecure_full.json", skip_time_verification=True
+        )
+        if not db_full:
+            LOG.debug(
+                "Cache data for insecure_full.json is not available or is invalid."
+            )
+        return db_full
+
     def __find_dependency_vulnerabilities__(
         self, dependencies: List[PythonDependency], config: ConfigModel
     ) -> None:
@@ -325,13 +341,8 @@ class PythonFile(InspectableFile, Remediable):
 
             if not dependency.version:
                 if not db_full:
-                    db_full = get_from_cache(
-                        db_name="insecure_full.json", skip_time_verification=True
-                    )
+                    db_full = self._load_full_db()
                     if not db_full:
-                        LOG.debug(
-                            "Cache data for insecure_full.json is not available or is invalid."
-                        )
                         return
                 dependency.refresh_from(db_full)
 
@@ -342,14 +353,8 @@ class PythonFile(InspectableFile, Remediable):
 
                     if spec.is_vulnerable(spec_set, dependency.insecure_versions):
                         if not db_full:
-                            db_full = get_from_cache(
-                                db_name="insecure_full.json",
-                                skip_time_verification=True,
-                            )
+                            db_full = self._load_full_db()
                             if not db_full:
-                                LOG.debug(
-                                    "Cache data for insecure_full.json is not available or is invalid."
-                                )
                                 return
                         if not dependency.latest_version:
                             dependency.refresh_from(db_full)
@@ -497,9 +502,7 @@ class PythonFile(InspectableFile, Remediable):
         """
         Remediates the vulnerabilities in the file.
         """
-        db_full = get_from_cache(
-            db_name="insecure_full.json", skip_time_verification=True
-        )
+        db_full = self._load_full_db()
         if not db_full:
             return
 

--- a/tests/scan/ecosystems/python/test_main.py
+++ b/tests/scan/ecosystems/python/test_main.py
@@ -1,6 +1,10 @@
 import unittest
-from unittest.mock import MagicMock
-from safety.scan.ecosystems.python.main import should_fail, VulnerabilitySeverityLabels
+from unittest.mock import MagicMock, patch
+from safety.scan.ecosystems.python.main import (
+    PythonFile,
+    should_fail,
+    VulnerabilitySeverityLabels,
+)
 
 
 class TestMain(unittest.TestCase):
@@ -80,3 +84,30 @@ class TestMain(unittest.TestCase):
             result = should_fail(self.config, self.vulnerability)
             self.assertIn("Unexpected base severity value", log.output[0])
         self.assertFalse(result)
+
+
+class TestLoadFullDb(unittest.TestCase):
+    def setUp(self):
+        self.python_file = PythonFile(file_type=MagicMock(), file=MagicMock())
+
+    @patch("safety.scan.ecosystems.python.main.get_from_cache")
+    def test_returns_db_when_cache_is_available(self, mock_get_from_cache):
+        db_full = {"vulnerable_packages": {}}
+        mock_get_from_cache.return_value = db_full
+
+        result = self.python_file._load_full_db()
+        self.assertIs(result, db_full)
+
+        mock_get_from_cache.assert_called_once_with(
+            db_name="insecure_full.json", skip_time_verification=True
+        )
+
+    @patch("safety.scan.ecosystems.python.main.get_from_cache")
+    def test_returns_none_and_logs_when_cache_is_missing(self, mock_get_from_cache):
+        mock_get_from_cache.return_value = None
+
+        with self.assertLogs(level="DEBUG") as log:
+            result = self.python_file._load_full_db()
+
+        self.assertIsNone(result)
+        self.assertIn("insecure_full.json", log.output[0])


### PR DESCRIPTION
## Description

`safety/scan/ecosystems/python/main.py` loaded the `insecure_full.json`
cache in three places with duplicated code: twice inside
`PythonFile.__find_dependency_vulnerabilities__` and once in
`PythonFile.remediate`. The cache name, the `skip_time_verification=True`
argument and the DEBUG log message were repeated at each site, so any
change to how that cache is read had to be made in three places.

This extracts the lookup into a `PythonFile._load_full_db()` helper.

Two notes on the approach:

- The early `return` stays at each call site rather than moving into the
  helper. Returning from inside the helper would let callers continue
  executing with `db_full` unset.
- `remediate()` previously loaded the same file without logging. It now
  emits the same DEBUG message as the other two call sites when the cache
  is unavailable.

No other behavior change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

## Related Issues

Part of #575 

## Testing

- [x] Tests added or updated
- [ ] No tests required

Adds `TestLoadFullDb` to `tests/scan/ecosystems/python/test_main.py`,
covering both outcomes:

- cache hit — the loaded database is returned as-is, and `get_from_cache`
  is called with `db_name="insecure_full.json", skip_time_verification=True`
- cache miss — `None` is returned and the DEBUG message is logged

`pytest tests/scan/ecosystems/python/test_main.py` passes locally (7 tests,
Python 3.14.3).

## Checklist

- [x] Code is well-documented
- [ ] Changelog is updated (if needed)
- [x] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes

`CHANGELOG.md` was intentionally left untouched — it states it is generated
automatically and should not be edited manually.

`ruff check` reports pre-existing findings on both touched files
(`UP006`, `UP035`, `B006`, `DTZ003`, `SIM102`, `SIM118`, `I001`). They are
identical on `main` and this PR introduces no new ones, so I left them
alone to keep the diff focused. Happy to fix them in a separate PR if you'd
like. `ruff format --check` is clean on both files.