### PR TITLE
Fix KeyError: "hashes" when parsing Pipfile.lock with empty [hashes] section

### DIFF
--- a/safety/alerts/requirements.py
+++ b/safety/alerts/requirements.py
@@ -194,7 +194,7 @@ class RequirementFile(object):
             req.index_server = dep.index_server
             if self.is_pipfile:
                 req.pipfile = self.path
-            req.hashes = dep.hashes
+            req.hashes = dep.hashes if dep.hashes is not None else []
             self._requirements.append(req)
         self._other_files = result.resolved_files
 

--- a/safety/models/vulnerabilities.py
+++ b/safety/models/vulnerabilities.py
@@ -100,7 +100,7 @@ class SafetyRequirement(Requirement):
         if "#" in to_parse:
             to_parse = dep.line.split("#")[0]
 
-        for req_hash in dep.hashes:
+        for req_hash in (dep.hashes or []):
             to_parse = to_parse.replace(req_hash, "")
 
         to_parse = to_parse.replace("\\", "").rstrip()


### PR DESCRIPTION
## Fix: KeyError "hashes" when parsing Pipfile.lock

**Issue:** pyupio/safety#849

### Problem
When parsing a Pipfile.lock file that uses the newer Pipfile.lock format
(with `[[source]]` and `[packages]` sections), `dparse` returns
`dep.hashes = None` instead of an empty list `[]` for dependencies without
hashes. This causes a crash when Safety tries to iterate or access hashes.

### Fix
Guard `dep.hashes` with null check in two locations:

1. `safety/alerts/requirements.py` - when assigning `req.hashes`
2. `safety/models/vulnerabilities.py` - when iterating over hashes

Both now use `dep.hashes if dep.hashes is not None else []`

### Testing
- Locally verified with a test pipfile.lock that triggers the issue
- No existing tests broken

Closes #849