### PR TITLE
fix: don't crash CLI dispatch when the Safety Platform is unreachable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,7 +296,8 @@ markers = [
     "linux: mark test to run only on Linux platforms",
     "darwin: mark test to run only on macOS platforms",
     "integration: mark test as integration test",
-    "slow: mark test as slow running"
+    "slow: mark test as slow running",
+    "requires_network: mark test as requiring outbound network access to the Safety Platform"
 ]
 
 [tool.coverage.run]

--- a/safety/cli_util.py
+++ b/safety/cli_util.py
@@ -21,6 +21,7 @@ from typing import (
 )
 
 import click
+import httpx
 import typer
 from rich.console import Console
 from rich.table import Table
@@ -40,6 +41,7 @@ from safety.constants import (
     CONTEXT_COMMAND_TYPE,
     FeatureType,
 )
+from safety.errors import NetworkConnectionError
 from safety.scan.constants import CONSOLE_HELP_THEME
 from safety.models import SafetyCLI
 from safety.auth import configure_auth_session
@@ -906,7 +908,13 @@ class SafetyCLILegacyGroup(click.Group):
             "key": ctx.params.pop("key", None),
             "stage": ctx.params.pop("stage", None),
         }
-        configure_auth_session(**session_kwargs)
+        try:
+            configure_auth_session(**session_kwargs)
+        except (httpx.RequestError, NetworkConnectionError) as e:
+            # Continue unauthenticated rather than aborting dispatch
+            LOG.warning("Unable to reach the Safety Platform: %s", e)
+            if not ctx.obj:
+                ctx.obj = SafetyCLI()
 
         # call initialize if the --key is used.
         if session_kwargs["key"]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@ from importlib.metadata import distributions
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 
+import socket
 import sys
+from urllib.parse import urlparse
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -55,13 +57,39 @@ _PLATFORM_MARKERS = {
 }
 
 
+def _can_resolve(url: str, timeout: float = 2.0) -> bool:
+    host = urlparse(url).hostname
+    if not host:
+        return False
+    try:
+        socket.setdefaulttimeout(timeout)
+        socket.gethostbyname(host)
+        return True
+    except OSError:
+        return False
+
+
+def _has_platform_network() -> bool:
+    from safety.auth.constants import SAFETY_PLATFORM_URL
+
+    return _can_resolve(SAFETY_PLATFORM_URL)
+
+
+_NETWORK_MARKERS = {
+    "requires_network": _has_platform_network(),
+}
+
+
 def pytest_collection_modifyitems(config, items):
-    for marker_name, condition_met in _PLATFORM_MARKERS.items():
+    for marker_name, condition_met in {**_PLATFORM_MARKERS, **_NETWORK_MARKERS}.items():
         if condition_met:
             continue
-        skip = pytest.mark.skip(
-            reason=f"requires {marker_name} (platform={sys.platform})"
+        reason = (
+            f"requires {marker_name} (platform={sys.platform})"
+            if marker_name in _PLATFORM_MARKERS
+            else "requires network access to the Safety Platform"
         )
+        skip = pytest.mark.skip(reason=reason)
         for item in items:
             if marker_name in item.keywords:
                 item.add_marker(skip)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import click
+import pytest
 from importlib.metadata import version
 
 from click.testing import CliRunner
@@ -220,6 +221,7 @@ class TestSafetyCLI(unittest.TestCase):
             self.assertEqual(result.exit_code, expected_exit_code)
             self.assertIn(expected, click.unstyle(result.output))
 
+    @pytest.mark.requires_network
     @patch("safety.safety.check")
     def test_check_vulnerabilities_found_default(self, check_func):
         check_func.return_value = [get_vulnerability()], None
@@ -227,6 +229,7 @@ class TestSafetyCLI(unittest.TestCase):
         result = self.runner.invoke(self.cli, ["check"])
         self.assertEqual(result.exit_code, EXPECTED_EXIT_CODE_VULNS_FOUND)
 
+    @pytest.mark.requires_network
     @patch("safety.safety.check")
     def test_check_vulnerabilities_not_found_default(self, check_func):
         check_func.return_value = [], None
@@ -234,6 +237,7 @@ class TestSafetyCLI(unittest.TestCase):
         result = self.runner.invoke(self.cli, ["check"])
         self.assertEqual(result.exit_code, EXPECTED_EXIT_CODE_VULNS_NOT_FOUND)
 
+    @pytest.mark.requires_network
     @patch("safety.safety.check")
     def test_check_vulnerabilities_found_with_outputs(self, check_func):
         check_func.return_value = [get_vulnerability()], None
@@ -243,6 +247,7 @@ class TestSafetyCLI(unittest.TestCase):
             result = self.runner.invoke(self.cli, ["check", "--output", output])
             self.assertEqual(result.exit_code, EXPECTED_EXIT_CODE_VULNS_FOUND)
 
+    @pytest.mark.requires_network
     @patch("safety.safety.check")
     def test_check_vulnerabilities_not_found_with_outputs(self, check_func):
         check_func.return_value = [], None
@@ -252,6 +257,7 @@ class TestSafetyCLI(unittest.TestCase):
             result = self.runner.invoke(self.cli, ["check", "--output", output])
             self.assertEqual(result.exit_code, EXPECTED_EXIT_CODE_VULNS_NOT_FOUND)
 
+    @pytest.mark.requires_network
     @patch("safety.safety.check")
     def test_check_continue_on_error(self, check_func):
         EXPECTED_EXIT_CODE_CONTINUE_ON_ERROR = 0
@@ -269,6 +275,7 @@ class TestSafetyCLI(unittest.TestCase):
                 )
                 self.assertEqual(result.exit_code, EXPECTED_EXIT_CODE_CONTINUE_ON_ERROR)
 
+    @pytest.mark.requires_network
     @patch("safety.safety.get_announcements")
     def test_announcements_if_is_not_tty(self, get_announcements_func):
         announcement = {"type": "error", "message": "Please upgrade now"}
@@ -278,6 +285,7 @@ class TestSafetyCLI(unittest.TestCase):
         self.assertTrue("ANNOUNCEMENTS" in result.stderr)
         self.assertTrue(message in result.stderr)
 
+    @pytest.mark.requires_network
     @patch("safety.safety.check")
     def test_check_ignore_format_backward_compatible(self, check):
         runner = CliRunner()
@@ -501,6 +509,7 @@ class TestSafetyCLI(unittest.TestCase):
         self.assertEqual(click.unstyle(result.stderr), msg)
         self.assertEqual(result.exit_code, 1)
 
+    @pytest.mark.requires_network
     def test_check_with_fix_does_verify_api_key(self):
         dirname = os.path.dirname(__file__)
         req_file = os.path.join(dirname, "test_fix", "basic", "reqs_simple.txt")
@@ -513,6 +522,7 @@ class TestSafetyCLI(unittest.TestCase):
         )
         self.assertEqual(result.exit_code, 65)
 
+    @pytest.mark.requires_network
     def test_check_with_fix_only_works_with_files(self):
         result = self.runner.invoke(
             self.cli, ["check", "--key", "TEST-API_KEY", "--apply-security-updates"]
@@ -523,6 +533,7 @@ class TestSafetyCLI(unittest.TestCase):
         )
         self.assertEqual(result.exit_code, 1)
 
+    @pytest.mark.requires_network
     @patch("safety.util.SafetyContext")
     @patch("safety.safety.check")
     @patch("safety.safety.calculate_remediations")
@@ -643,6 +654,7 @@ class TestSafetyCLI(unittest.TestCase):
             with open(req_file) as f:
                 self.assertEqual("django==2.0\nsafety==2.3.0\nflask==0.87.0", f.read())
 
+    @pytest.mark.requires_network
     def test_check_ignore_unpinned_requirements(self):
         dirname = os.path.dirname(__file__)
         db = os.path.join(dirname, "test_db")
@@ -739,6 +751,7 @@ class TestSafetyCLI(unittest.TestCase):
         except json.JSONDecodeError:
             self.fail(f"Failed to parse JSON output. Extracted JSON was: {json_output}")
 
+    @pytest.mark.requires_network
     def test_basic_html_output_pass(self):
         dirname = os.path.dirname(__file__)
         db = os.path.join(dirname, "test_db")
@@ -763,6 +776,7 @@ class TestSafetyCLI(unittest.TestCase):
         self.assertIn("remediations-suggested", result.stdout)
         self.assertIn("Use API Key", result.stdout)
 
+    @pytest.mark.requires_network
     @patch("safety.safety.fetch_database_url")
     def test_license_with_file(self, fetch_database_url):
         licenses_db = {
@@ -781,6 +795,7 @@ class TestSafetyCLI(unittest.TestCase):
         print(result.stdout)
         self.assertEqual(result.exit_code, 0)
 
+    @pytest.mark.requires_network
     @patch("safety.auth.cli.get_auth_info", return_value={"email": "test@test.com"})
     @patch.object(Auth, "is_valid", return_value=True)
     @patch(
@@ -869,6 +884,7 @@ class TestSafetyCLI(unittest.TestCase):
             f"Preprocessed args: {preprocessed_args}"
         )
 
+    @pytest.mark.requires_network
     @patch("safety.auth.utils.get_config_setting", return_value=None)
     @patch("safety.auth.cli.get_auth_info", return_value={"email": "test@test.com"})
     @patch.object(Auth, "is_valid", return_value=True)
@@ -941,6 +957,7 @@ class TestSafetyCLI(unittest.TestCase):
                             f"Output: {cleaned_stdout}\n"
                         )
 
+    @pytest.mark.requires_network
     @patch("safety.auth.cli.get_auth_info", return_value={"email": "test@test.com"})
     @patch.object(Auth, "is_valid", return_value=True)
     @patch(


### PR DESCRIPTION
## Description

Context: Updating the python-safety package on Guix, and a lot of tests fail due to network being unreachable in the CI.

Disclaimer: I used generative AI solutions in the process, but tested changes properly manually.

SafetyCLILegacyGroup.invoke() called configure_auth_session() unconditionally and without exception handling. When the platform's TLS connectivity probe hit a network failure (DNS, connect, timeout), the resulting httpx.ConnectError propagated uncaught through Click's dispatch, aborting every command regardless of whether it actually needed authentication.

Catch httpx.RequestError/NetworkConnectionError there and continue with an unauthenticated session instead. Commands that need auth already handle ctx.obj.auth being unset; commands that don't need it (validate, generate, etc.) now work without network access.

Tests that still genuinely require the real platform are marked with a new requires_network pytest marker, which self-skips when the platform host can't be resolved, following the existing _PLATFORM_MARKERS pattern in tests/conftest.py.

## Type of Change

- [x] Bug fix

## Related Issues

<!-- List any related issues or reference other PRs, if applicable. Example: Fixes #123, Closes #456 -->

## Testing

- [ ] Tests added or updated
- [ ] No tests required

<!-- Briefly describe the testing that was done. Include steps to manually test or reference automated tests. -->

## Checklist

- [ ] Code is well-documented
- [ ] Changelog is updated (if needed)
- [ ] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes

<!-- Any additional notes or comments to help the reviewer. -->
