### PR TITLE
Fix exit code bug when no policy is present and fix --policy-file ignore

### DIFF
--- a/safety/scan/command.py
+++ b/safety/scan/command.py
@@ -947,12 +947,18 @@ def scan(
         ):
             # Update counts and track vulnerabilities
             count += len(analyzed_file.dependency_results.dependencies)
-            if exit_code == 0 and analyzed_file.dependency_results.failed:
-                exit_code = EXIT_CODE_VULNERABILITIES_FOUND
 
             affected_specifications = (
                 analyzed_file.dependency_results.get_affected_specifications()
             )
+            
+            if exit_code == 0:
+                if analyzed_file.dependency_results.failed:
+                    exit_code = EXIT_CODE_VULNERABILITIES_FOUND
+                elif not ctx.obj.project.policy:
+                    if any(not vuln.ignored for spec in affected_specifications for vuln in spec.vulnerabilities):
+                        exit_code = EXIT_CODE_VULNERABILITIES_FOUND
+
             affected_count += len(affected_specifications)
 
             # Sort vulnerabilities by severity

--- a/safety/scan/decorators.py
+++ b/safety/scan/decorators.py
@@ -113,6 +113,8 @@ def scan_project_command_init(func):
         ctx.obj.project.git = git_data
         ctx.obj.project.upload_request_id = upload_request_id
 
+        is_explicit_policy_file = policy_file_path is not None
+
         if not policy_file_path:
             policy_file_path = target / Path(".safety-policy.yml")
 
@@ -120,7 +122,7 @@ def scan_project_command_init(func):
         local_policy = kwargs.pop("local_policy", load_policy_file(policy_file_path))
 
         cloud_policy = None
-        if ctx.obj.platform_enabled:
+        if ctx.obj.platform_enabled and not is_explicit_policy_file:
             cloud_policy = print_wait_policy_download(
                 console,
                 (
@@ -134,7 +136,10 @@ def scan_project_command_init(func):
                 ),
             )
 
-        ctx.obj.project.policy = resolve_policy(local_policy, cloud_policy)
+        if is_explicit_policy_file and local_policy:
+            ctx.obj.project.policy = local_policy
+        else:
+            ctx.obj.project.policy = resolve_policy(local_policy, cloud_policy)
         config = (
             ctx.obj.project.policy.config
             if ctx.obj.project.policy and ctx.obj.project.policy.config


### PR DESCRIPTION
Fixes #821 and #859. When no policy is present, safety scan now correctly returns a non-zero exit code if vulnerabilities are found. When a local policy file is explicitly provided with --policy-file, it is no longer ignored in favor of the cloud policy.