### PR TITLE
refactor(auth): migrate JOSE/JWT calls from authlib.jose to joserfc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
   "Authlib>=1.2.0",
+  "joserfc>=1.0.0",
   "Click>=8.0.2",
   "dparse>=0.6.4",
   "filelock>=3.16.1,<4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
   "Authlib>=1.2.0",
-  "joserfc>=1.0.0",
+  "joserfc>=1.3.0",
   "Click>=8.0.2",
   "dparse>=0.6.4",
   "filelock>=3.16.1,<4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
   "Authlib>=1.2.0",
-  "joserfc>=1.3.0",
+  "joserfc>=1.1.0",
   "Click>=8.0.2",
   "dparse>=0.6.4",
   "filelock>=3.16.1,<4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-  "Authlib>=1.2.0",
+  "Authlib>=1.6.12,<2.0",
   "joserfc>=1.1.0",
   "Click>=8.0.2",
   "dparse>=0.6.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
   "Authlib>=1.6.12,<2.0",
-  "joserfc>=1.1.0",
+  "joserfc>=1.6.8",
   "Click>=8.0.2",
   "dparse>=0.6.4",
   "filelock>=3.16.1,<4.0",

--- a/safety/auth/cli.py
+++ b/safety/auth/cli.py
@@ -1,4 +1,8 @@
 # type: ignore
+# Pre-existing typing/style debt below is out of scope for the JWT migration.
+# Adding `from __future__ import annotations` here would change how Typer
+# resolves command annotations at runtime, so it is deferred to its own PR.
+# ruff: noqa: DTZ005, FA100, I001, UP035
 import logging
 import os
 import re

--- a/safety/auth/cli.py
+++ b/safety/auth/cli.py
@@ -73,14 +73,14 @@ def _extract_org_uuid_from_jwt(ctx: "typer.Context") -> str:
     if not auth_config:
         return ""
     try:
-        claims = get_token_claims(
+        decoded = get_token_claims(
             auth_config.access_token,
             "access_token",
             ctx.obj.auth.jwks,
             silent_if_expired=True,
         )
-        if claims:
-            org_uuid = claims.get("https://api.safetycli.com/org_uuid", "")
+        if decoded is not None:
+            org_uuid = decoded.claims.get("https://api.safetycli.com/org_uuid", "")
             return str(org_uuid) if org_uuid else ""
     except Exception:
         LOG.warning("Failed to extract org UUID from access token", exc_info=True)

--- a/safety/auth/main.py
+++ b/safety/auth/main.py
@@ -118,16 +118,16 @@ def get_id_token_claims(jwks: dict[str, Any]) -> dict:
     if not id_token:
         raise ValueError("Invalid auth config.")
 
-    claims = Token.get_claims_for(
+    decoded = Token.get_claims_for(
         token=id_token,
         token_type="id_token",
         jwks=jwks,
     )
 
-    if not claims:
+    if decoded is None:
         raise ValueError("Unable to get claims for id_token.")
 
-    return claims
+    return decoded.claims
 
 
 def get_auth_info(auth: Auth) -> dict | None:

--- a/safety/auth/main.py
+++ b/safety/auth/main.py
@@ -1,35 +1,35 @@
+from __future__ import annotations
+
 import configparser
-
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
-
-from joserfc.errors import ExpiredTokenError
-
-from safety.auth.models import Organization
-from safety.auth.constants import (
-    CLI_AUTH_LOGOUT,
-    CLI_CALLBACK,
-    CLI_AUTH,
-)
-from safety.auth.oauth2 import Token
-from safety.config import AuthConfig, AUTH_CONFIG_USER
-from safety.constants import CONFIG
-from safety.utils.auth_session import discard_token
-from safety_schemas.models import Stage
+from typing import TYPE_CHECKING, Any
 
 from authlib.integrations.httpx_client import OAuth2Client
+from joserfc.errors import ExpiredTokenError
+from safety_schemas.models import Stage
+
+from safety.auth.constants import (
+    CLI_AUTH,
+    CLI_AUTH_LOGOUT,
+    CLI_CALLBACK,
+)
+from safety.auth.models import Organization
+from safety.auth.oauth2 import Token
+from safety.config import AUTH_CONFIG_USER, AuthConfig
+from safety.constants import CONFIG
+from safety.utils.auth_session import discard_token
 
 if TYPE_CHECKING:
     from safety.auth.models import Auth
 
 
 def get_authorization_data(
-    http_client: "OAuth2Client",
+    http_client: OAuth2Client,
     code_verifier: str,
-    organization: Optional[Organization] = None,
+    organization: Organization | None = None,
     sign_up: bool = False,
     ensure_auth: bool = False,
     headless: bool = False,
-) -> Tuple[str, str]:
+) -> tuple[str, str]:
     """
     Generate the authorization URL for the authentication process.
 
@@ -82,7 +82,7 @@ def get_redirect_url() -> str:
     return CLI_CALLBACK
 
 
-def get_organization() -> Optional[Organization]:
+def get_organization() -> Organization | None:
     """
     Retrieve the organization configuration.
 
@@ -92,13 +92,13 @@ def get_organization() -> Optional[Organization]:
     config = configparser.ConfigParser()
     config.read(CONFIG)
 
-    org_conf: Union[Dict[str, str], configparser.SectionProxy] = (
+    org_conf: dict[str, str] | configparser.SectionProxy = (
         config["organization"] if "organization" in config.sections() else {}
     )
-    org_id: Optional[str] = (
+    org_id: str | None = (
         org_conf["id"].replace('"', "") if org_conf.get("id", None) else None
     )
-    org_name: Optional[str] = (
+    org_name: str | None = (
         org_conf["name"].replace('"', "") if org_conf.get("name", None) else None
     )
 
@@ -110,7 +110,7 @@ def get_organization() -> Optional[Organization]:
     return org
 
 
-def get_id_token_claims(jwks: Dict[str, Any]) -> Dict:
+def get_id_token_claims(jwks: dict[str, Any]) -> dict:
     id_token = None
     if auth_config := AuthConfig.from_storage():
         id_token = auth_config.id_token
@@ -130,7 +130,7 @@ def get_id_token_claims(jwks: Dict[str, Any]) -> Dict:
     return claims
 
 
-def get_auth_info(auth: "Auth") -> Optional[Dict]:
+def get_auth_info(auth: Auth) -> dict | None:
     """
     Retrieve the authentication information.
 
@@ -174,15 +174,15 @@ def get_auth_info(auth: "Auth") -> Optional[Dict]:
                 )
                 info = get_id_token_claims(jwks=auth.jwks)
 
-            except Exception as _e:
+            except Exception as _e:  # noqa: BLE001
                 discard_token(oauth2_client=oauth2_client)
-        except Exception as _g:
+        except Exception as _g:  # noqa: BLE001
             discard_token(oauth2_client=oauth2_client)
 
     return info
 
 
-def get_token(name: str = "access_token") -> Optional[str]:
+def get_token(name: str = "access_token") -> str | None:
     """ "
     Retrieve a token from the local authentication configuration.
 
@@ -206,7 +206,7 @@ def get_token(name: str = "access_token") -> Optional[str]:
     return None
 
 
-def get_host_config(key_name: str) -> Optional[Any]:
+def get_host_config(key_name: str) -> Any | None:
     """
     Retrieve a configuration value from the host configuration.
 
@@ -224,14 +224,13 @@ def get_host_config(key_name: str) -> Optional[Any]:
 
     host_section = dict(config.items("host"))
 
-    if key_name in host_section:
-        if key_name == "stage":
-            # Support old alias in the config.ini
-            if host_section[key_name] == "dev":
-                host_section[key_name] = "development"
-            if host_section[key_name] not in {env.value for env in Stage}:
-                return None
-            return Stage(host_section[key_name])
+    if key_name in host_section and key_name == "stage":
+        # Support old alias in the config.ini
+        if host_section[key_name] == "dev":
+            host_section[key_name] = "development"
+        if host_section[key_name] not in {env.value for env in Stage}:
+            return None
+        return Stage(host_section[key_name])
 
     return None
 

--- a/safety/auth/main.py
+++ b/safety/auth/main.py
@@ -2,7 +2,7 @@ import configparser
 
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
-from authlib.jose.errors import ExpiredTokenError
+from joserfc.errors import ExpiredTokenError
 
 from safety.auth.models import Organization
 from safety.auth.constants import (
@@ -163,7 +163,7 @@ def get_auth_info(auth: "Auth") -> Optional[Dict]:
 
                 if verified:
                     # refresh only if needed
-                    raise ExpiredTokenError
+                    raise ExpiredTokenError("exp")
 
         except ExpiredTokenError:
             # id_token expired. So fire a manually a refresh

--- a/safety/auth/oauth2.py
+++ b/safety/auth/oauth2.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Literal
 
 from authlib.oauth2.rfc6749 import OAuth2Token
+from joserfc.jwt import Token as JWTToken
 
 from safety.config import AuthConfig
 from safety.logs_helpers import log_call
@@ -19,7 +20,7 @@ class Token:
         token_type: Literal["access_token", "id_token"],
         jwks: dict[str, Any],
         silent_if_expired: bool = False,
-    ) -> dict[str, Any] | None:
+    ) -> JWTToken | None:
         """
         Decode and validate the token data.
 
@@ -30,7 +31,7 @@ class Token:
             silent_if_expired (bool): Whether to silently ignore expired tokens.
 
         Returns:
-            Optional[dict[str, Any]]: The decoded token claims, or None if invalid.
+            The decoded joserfc `Token` (payload via `.claims`), or None if invalid.
         """
         return get_token_claims(token, token_type, jwks, silent_if_expired)
 

--- a/safety/auth/oauth2.py
+++ b/safety/auth/oauth2.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from authlib.oauth2.rfc6749 import OAuth2Token
-from authlib.oidc.core import CodeIDToken
 from typing import Any, Dict, Literal, Optional
 
 import logging
@@ -20,7 +19,7 @@ class Token:
         token_type: Literal["access_token", "id_token"],
         jwks: Dict[str, Any],
         silent_if_expired: bool = False,
-    ) -> Optional[CodeIDToken]:
+    ) -> Optional[dict[str, Any]]:
         """
         Decode and validate the token data.
 
@@ -31,7 +30,7 @@ class Token:
             silent_if_expired (bool): Whether to silently ignore expired tokens.
 
         Returns:
-            Optional[CodeIDToken]: The decoded token data, or None if invalid.
+            Optional[dict[str, Any]]: The decoded token claims, or None if invalid.
         """
         return get_token_claims(token, token_type, jwks, silent_if_expired)
 

--- a/safety/auth/oauth2.py
+++ b/safety/auth/oauth2.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from authlib.oauth2.rfc6749 import OAuth2Token
-from typing import Any, Dict, Literal, Optional
-
 import logging
-from safety.logs_helpers import log_call
+from typing import Any, Literal
 
-from safety.utils.tokens import get_token_claims
+from authlib.oauth2.rfc6749 import OAuth2Token
+
 from safety.config import AuthConfig
+from safety.logs_helpers import log_call
+from safety.utils.tokens import get_token_claims
 
 logger = logging.getLogger(__name__)
 
@@ -17,9 +17,9 @@ class Token:
     def get_claims_for(
         token: str,
         token_type: Literal["access_token", "id_token"],
-        jwks: Dict[str, Any],
+        jwks: dict[str, Any],
         silent_if_expired: bool = False,
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """
         Decode and validate the token data.
 

--- a/safety/config/auth.py
+++ b/safety/config/auth.py
@@ -1,3 +1,7 @@
+# Pre-existing typing/style debt below is out of scope for the JWT migration.
+# Modernizing the annotations (PEP 585/604) would break the runtime `cast()`
+# calls on Python 3.9, so it is deferred to its own PR.
+# ruff: noqa: FA100, I001, UP006, UP035
 from authlib.oauth2.rfc6749 import OAuth2Token
 from dataclasses import dataclass
 import configparser

--- a/safety/config/auth.py
+++ b/safety/config/auth.py
@@ -144,14 +144,14 @@ class AuthConfig:
         Returns:
             OAuth2Token: The OAuth2 token.
         """
-        claims = get_token_claims(
+        decoded = get_token_claims(
             self.access_token, "access_token", jwks, silent_if_expired=True
         )
 
-        if not claims:
+        if decoded is None:
             raise ValueError("Invalid access token")
 
-        expires_at = claims.get(self._CLAIMS_EXPIRES_AT, None)
+        expires_at = decoded.claims.get(self._CLAIMS_EXPIRES_AT, None)
 
         if not expires_at:
             raise ValueError("Invalid access token, missing expiration time.")

--- a/safety/utils/tokens.py
+++ b/safety/utils/tokens.py
@@ -5,12 +5,16 @@ Token validation utilities shared across the application.
 from typing import Any, Dict, Literal, Optional
 import logging
 
-from authlib.oidc.core import CodeIDToken
-from authlib.jose import jwt
-from authlib.jose.errors import ExpiredTokenError
+from joserfc import jwt
+from joserfc.jwk import KeySet
+from joserfc.errors import ExpiredTokenError
 
 
 logger = logging.getLogger(__name__)
+
+# JWTClaimsRegistry is stateless once constructed; reuse a single instance
+# across calls instead of allocating per decode.
+_CLAIMS_REGISTRY = jwt.JWTClaimsRegistry()
 
 
 def get_token_claims(
@@ -18,7 +22,7 @@ def get_token_claims(
     token_type: Literal["access_token", "id_token"],
     jwks: Dict[str, Any],
     silent_if_expired: bool = False,
-) -> Optional[CodeIDToken]:
+) -> Optional[dict[str, Any]]:
     """
     Decode and validate token claims.
 
@@ -26,10 +30,14 @@ def get_token_claims(
         token: The token to decode
         token_type: Type of token (access_token or id_token)
         jwks: JSON Web Key Set for validation
-        silent_if_expired: Whether to silently ignore expired tokens
+        silent_if_expired: If True, suppress ExpiredTokenError and still
+            return the decoded claims (callers may need fields like
+            ``exp`` or custom claims from an expired token).
 
     Returns:
-        Decoded token claims, or None if invalid
+        Decoded token claims as a dict, or None if decoding failed.
+        When ``silent_if_expired`` is True and the token is expired,
+        the claims are still returned.
 
     Raises:
         ValueError: If token_type is invalid
@@ -41,10 +49,12 @@ def get_token_claims(
     claims = None
 
     try:
-        claims = jwt.decode(token, jwks, claims_cls=CodeIDToken)  # type: ignore
-        claims.validate()
-    except ExpiredTokenError as e:
+        key_set = KeySet.import_key_set(jwks)
+        token_obj = jwt.decode(token, key_set)
+        claims = token_obj.claims
+        _CLAIMS_REGISTRY.validate(claims)
+    except ExpiredTokenError:
         if not silent_if_expired:
-            raise e
+            raise
 
     return claims

--- a/safety/utils/tokens.py
+++ b/safety/utils/tokens.py
@@ -50,7 +50,7 @@ def get_token_claims(
     claims = None
 
     try:
-        key_set = KeySet.import_key_set(jwks)
+        key_set = KeySet.import_key_set(jwks)  # type: ignore
         token_obj = jwt.decode(token, key_set)
         claims = token_obj.claims
         _CLAIMS_REGISTRY.validate(claims)

--- a/safety/utils/tokens.py
+++ b/safety/utils/tokens.py
@@ -2,13 +2,14 @@
 Token validation utilities shared across the application.
 """
 
-from typing import Any, Dict, Literal, Optional
+from __future__ import annotations
+
 import logging
+from typing import Any, Literal
 
 from joserfc import jwt
-from joserfc.jwk import KeySet
 from joserfc.errors import ExpiredTokenError
-
+from joserfc.jwk import KeySet
 
 logger = logging.getLogger(__name__)
 
@@ -20,9 +21,9 @@ _CLAIMS_REGISTRY = jwt.JWTClaimsRegistry()
 def get_token_claims(
     token: str,
     token_type: Literal["access_token", "id_token"],
-    jwks: Dict[str, Any],
+    jwks: dict[str, Any],
     silent_if_expired: bool = False,
-) -> Optional[dict[str, Any]]:
+) -> dict[str, Any] | None:
     """
     Decode and validate token claims.
 

--- a/safety/utils/tokens.py
+++ b/safety/utils/tokens.py
@@ -13,10 +13,6 @@ from joserfc.jwk import KeySet
 
 logger = logging.getLogger(__name__)
 
-# JWTClaimsRegistry is stateless once constructed; reuse a single instance
-# across calls instead of allocating per decode.
-_CLAIMS_REGISTRY = jwt.JWTClaimsRegistry()
-
 # Pin decoding to the asymmetric algorithms our IdP advertises (RS256 today,
 # PS256 if it rotates) and deliberately exclude the symmetric HS* family. This
 # blocks the HS* alg-confusion path (a token that HMAC-signs itself with the
@@ -39,11 +35,11 @@ def get_token_claims(
         jwks: JSON Web Key Set for validation
         silent_if_expired: If True, suppress ExpiredTokenError and still
             return the decoded claims (callers may need fields like
-            ``exp`` or custom claims from an expired token).
+            `exp` or custom claims from an expired token).
 
     Returns:
         Decoded token claims as a dict, or None if decoding failed.
-        When ``silent_if_expired`` is True and the token is expired,
+        When `silent_if_expired` is True and the token is expired,
         the claims are still returned.
 
     Raises:
@@ -59,7 +55,7 @@ def get_token_claims(
         key_set = KeySet.import_key_set(jwks)  # type: ignore
         token_obj = jwt.decode(token, key_set, algorithms=_ALLOWED_ALGORITHMS)
         claims = token_obj.claims
-        _CLAIMS_REGISTRY.validate(claims)
+        jwt.JWTClaimsRegistry().validate(claims)
     except ExpiredTokenError:
         if not silent_if_expired:
             raise

--- a/safety/utils/tokens.py
+++ b/safety/utils/tokens.py
@@ -17,6 +17,12 @@ logger = logging.getLogger(__name__)
 # across calls instead of allocating per decode.
 _CLAIMS_REGISTRY = jwt.JWTClaimsRegistry()
 
+# Pin decoding to the asymmetric algorithms our IdP advertises (RS256 today,
+# PS256 if it rotates) and deliberately exclude the symmetric HS* family. This
+# blocks the HS* alg-confusion path (a token that HMAC-signs itself with the
+# JWKS public key) even if a symmetric key is ever added to the JWKS.
+_ALLOWED_ALGORITHMS = ["RS256", "PS256"]
+
 
 def get_token_claims(
     token: str,
@@ -51,7 +57,7 @@ def get_token_claims(
 
     try:
         key_set = KeySet.import_key_set(jwks)  # type: ignore
-        token_obj = jwt.decode(token, key_set)
+        token_obj = jwt.decode(token, key_set, algorithms=_ALLOWED_ALGORITHMS)
         claims = token_obj.claims
         _CLAIMS_REGISTRY.validate(claims)
     except ExpiredTokenError:

--- a/safety/utils/tokens.py
+++ b/safety/utils/tokens.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 from joserfc import jwt
 from joserfc.errors import ExpiredTokenError
 from joserfc.jwk import KeySet
+from joserfc.jwt import Token as JWTToken
 
 logger = logging.getLogger(__name__)
 
@@ -25,22 +26,22 @@ def get_token_claims(
     token_type: Literal["access_token", "id_token"],
     jwks: dict[str, Any],
     silent_if_expired: bool = False,
-) -> dict[str, Any] | None:
+) -> JWTToken | None:
     """
-    Decode and validate token claims.
+    Decode and validate a token.
 
     Args:
         token: The token to decode
         token_type: Type of token (access_token or id_token)
         jwks: JSON Web Key Set for validation
         silent_if_expired: If True, suppress ExpiredTokenError and still
-            return the decoded claims (callers may need fields like
-            `exp` or custom claims from an expired token).
+            return the decoded token (callers may need fields like `exp`
+            or custom claims, read via `.claims`, from an expired token).
 
     Returns:
-        Decoded token claims as a dict, or None if decoding failed.
-        When `silent_if_expired` is True and the token is expired,
-        the claims are still returned.
+        The decoded joserfc `Token` (its `.claims` holds the payload), or
+        None if decoding failed. When `silent_if_expired` is True and the
+        token is expired, the decoded token is still returned.
 
     Raises:
         ValueError: If token_type is invalid
@@ -49,15 +50,14 @@ def get_token_claims(
     if token_type not in ("access_token", "id_token"):
         raise ValueError(f"Invalid token_type: {token_type}")
 
-    claims = None
+    decoded = None
 
     try:
         key_set = KeySet.import_key_set(jwks)  # type: ignore
-        token_obj = jwt.decode(token, key_set, algorithms=_ALLOWED_ALGORITHMS)
-        claims = token_obj.claims
-        jwt.JWTClaimsRegistry().validate(claims)
+        decoded = jwt.decode(token, key_set, algorithms=_ALLOWED_ALGORITHMS)
+        jwt.JWTClaimsRegistry().validate(decoded.claims)
     except ExpiredTokenError:
         if not silent_if_expired:
             raise
 
-    return claims
+    return decoded

--- a/tests/config/test_machine_credential.py
+++ b/tests/config/test_machine_credential.py
@@ -7,8 +7,14 @@ from unittest.mock import patch
 
 import pytest
 from authlib.oauth2.rfc6749 import OAuth2Token
+from joserfc.jwt import Token as JWTToken
 
 from safety.config.auth import AuthConfig, MachineCredentialConfig
+
+
+def _decoded(claims: Dict) -> JWTToken:
+    """A joserfc Token wrapping the given claims (what get_token_claims returns)."""
+    return JWTToken({"alg": "RS256"}, claims)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -611,7 +617,7 @@ class TestAuthConfigToToken:
         )
         mock_claims = {"exp": 1700000000}
 
-        with patch("safety.config.auth.get_token_claims", return_value=mock_claims):
+        with patch("safety.config.auth.get_token_claims", return_value=_decoded(mock_claims)):
             token = auth.to_token(jwks={"keys": []})
 
         assert token["access_token"] == "at-test"
@@ -641,7 +647,7 @@ class TestAuthConfigToToken:
         )
         mock_claims = {"sub": "user-123"}  # Has content but no "exp" key
 
-        with patch("safety.config.auth.get_token_claims", return_value=mock_claims):
+        with patch("safety.config.auth.get_token_claims", return_value=_decoded(mock_claims)):
             with pytest.raises(ValueError, match="missing expiration"):
                 auth.to_token(jwks={"keys": []})
 
@@ -656,7 +662,7 @@ class TestAuthConfigToToken:
         mock_claims = {"exp": 1700000000}
 
         with patch(
-            "safety.config.auth.get_token_claims", return_value=mock_claims
+            "safety.config.auth.get_token_claims", return_value=_decoded(mock_claims)
         ) as mock_get_claims:
             auth.to_token(jwks=jwks)
 

--- a/tests/config/test_machine_credential.py
+++ b/tests/config/test_machine_credential.py
@@ -1,3 +1,6 @@
+# Pre-existing typing/style debt below is out of scope for the JWT migration;
+# modernizing it is deferred to its own PR.
+# ruff: noqa: FA100, SIM117, UP006, UP035
 import configparser
 import multiprocessing
 import time
@@ -617,7 +620,9 @@ class TestAuthConfigToToken:
         )
         mock_claims = {"exp": 1700000000}
 
-        with patch("safety.config.auth.get_token_claims", return_value=_decoded(mock_claims)):
+        with patch(
+            "safety.config.auth.get_token_claims", return_value=_decoded(mock_claims)
+        ):
             token = auth.to_token(jwks={"keys": []})
 
         assert token["access_token"] == "at-test"
@@ -647,7 +652,9 @@ class TestAuthConfigToToken:
         )
         mock_claims = {"sub": "user-123"}  # Has content but no "exp" key
 
-        with patch("safety.config.auth.get_token_claims", return_value=_decoded(mock_claims)):
+        with patch(
+            "safety.config.auth.get_token_claims", return_value=_decoded(mock_claims)
+        ):
             with pytest.raises(ValueError, match="missing expiration"):
                 auth.to_token(jwks={"keys": []})
 

--- a/tests/utils/test_tokens.py
+++ b/tests/utils/test_tokens.py
@@ -45,8 +45,8 @@ def test_expired_token_raises_when_not_silent() -> None:
     key, jwks = _key_and_jwks()
     token = _sign(key, {"sub": "user-1", "exp": int(time.time()) - 10})
 
-    # Guards the reused-registry behavior: the module-level JWTClaimsRegistry
-    # must read the clock per call, so an already-expired token is rejected.
+    # A JWTClaimsRegistry is constructed per call, so it reads the clock at
+    # validate time and an already-expired token is rejected.
     with pytest.raises(ExpiredTokenError):
         get_token_claims(token, "id_token", jwks, silent_if_expired=False)
 

--- a/tests/utils/test_tokens.py
+++ b/tests/utils/test_tokens.py
@@ -8,12 +8,13 @@ regression in the reused JWTClaimsRegistry or the expiry branch is caught.
 from __future__ import annotations
 
 import time
+import warnings
 from typing import Any
 
 import pytest
 from joserfc import jwt as joserfc_jwt
-from joserfc.errors import ExpiredTokenError
-from joserfc.jwk import RSAKey
+from joserfc.errors import ExpiredTokenError, UnsupportedAlgorithmError
+from joserfc.jwk import OctKey, RSAKey
 
 from safety.utils.tokens import get_token_claims
 
@@ -66,3 +67,20 @@ def test_invalid_token_type_raises_value_error() -> None:
 
     with pytest.raises(ValueError):
         get_token_claims(token, "bogus", jwks)  # type: ignore[arg-type]
+
+
+def test_alg_confusion_hs256_is_rejected() -> None:
+    # Forge an HS256 token whose HMAC secret is the RSA public key from the
+    # JWKS. Without the algorithm allowlist joserfc would verify it; the
+    # allowlist refuses the disallowed alg before any key is used.
+    key, jwks = _key_and_jwks()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # joserfc warns on RSA-PEM-as-oct-key
+        forged = joserfc_jwt.encode(
+            {"alg": "HS256", "kid": "test-kid"},
+            {"sub": "attacker", "exp": int(time.time()) + 3600},
+            OctKey.import_key(key.as_pem(private=False)),
+        )
+
+    with pytest.raises(UnsupportedAlgorithmError):
+        get_token_claims(forged, "id_token", jwks)

--- a/tests/utils/test_tokens.py
+++ b/tests/utils/test_tokens.py
@@ -2,7 +2,7 @@
 Unit tests for safety.utils.tokens.get_token_claims().
 
 These exercise the real joserfc decode path rather than mocking it, so a
-regression in the reused JWTClaimsRegistry or the expiry branch is caught.
+regression in the per-call JWTClaimsRegistry or the expiry branch is caught.
 """
 
 from __future__ import annotations
@@ -34,11 +34,11 @@ def test_valid_token_returns_claims() -> None:
     key, jwks = _key_and_jwks()
     token = _sign(key, {"sub": "user-1", "org": "acme", "exp": int(time.time()) + 3600})
 
-    claims = get_token_claims(token, "id_token", jwks)
+    decoded = get_token_claims(token, "id_token", jwks)
 
-    assert claims is not None
-    assert claims["sub"] == "user-1"
-    assert claims["org"] == "acme"
+    assert decoded is not None
+    assert decoded.claims["sub"] == "user-1"
+    assert decoded.claims["org"] == "acme"
 
 
 def test_expired_token_raises_when_not_silent() -> None:
@@ -55,10 +55,10 @@ def test_expired_token_returns_claims_when_silent() -> None:
     key, jwks = _key_and_jwks()
     token = _sign(key, {"sub": "user-1", "exp": int(time.time()) - 10})
 
-    claims = get_token_claims(token, "id_token", jwks, silent_if_expired=True)
+    decoded = get_token_claims(token, "id_token", jwks, silent_if_expired=True)
 
-    assert claims is not None
-    assert claims["sub"] == "user-1"
+    assert decoded is not None
+    assert decoded.claims["sub"] == "user-1"
 
 
 def test_invalid_token_type_raises_value_error() -> None:

--- a/tests/utils/test_tokens.py
+++ b/tests/utils/test_tokens.py
@@ -1,0 +1,68 @@
+"""
+Unit tests for safety.utils.tokens.get_token_claims().
+
+These exercise the real joserfc decode path rather than mocking it, so a
+regression in the reused JWTClaimsRegistry or the expiry branch is caught.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+from joserfc import jwt as joserfc_jwt
+from joserfc.errors import ExpiredTokenError
+from joserfc.jwk import RSAKey
+
+from safety.utils.tokens import get_token_claims
+
+_HEADER = {"alg": "RS256", "kid": "test-kid"}
+
+
+def _key_and_jwks() -> tuple[RSAKey, dict[str, Any]]:
+    key = RSAKey.generate_key(2048, parameters={"kid": "test-kid"})
+    return key, {"keys": [key.as_dict(private=False)]}
+
+
+def _sign(key: RSAKey, claims: dict[str, Any]) -> str:
+    return joserfc_jwt.encode(_HEADER, claims, key)
+
+
+def test_valid_token_returns_claims() -> None:
+    key, jwks = _key_and_jwks()
+    token = _sign(key, {"sub": "user-1", "org": "acme", "exp": int(time.time()) + 3600})
+
+    claims = get_token_claims(token, "id_token", jwks)
+
+    assert claims is not None
+    assert claims["sub"] == "user-1"
+    assert claims["org"] == "acme"
+
+
+def test_expired_token_raises_when_not_silent() -> None:
+    key, jwks = _key_and_jwks()
+    token = _sign(key, {"sub": "user-1", "exp": int(time.time()) - 10})
+
+    # Guards the reused-registry behavior: the module-level JWTClaimsRegistry
+    # must read the clock per call, so an already-expired token is rejected.
+    with pytest.raises(ExpiredTokenError):
+        get_token_claims(token, "id_token", jwks, silent_if_expired=False)
+
+
+def test_expired_token_returns_claims_when_silent() -> None:
+    key, jwks = _key_and_jwks()
+    token = _sign(key, {"sub": "user-1", "exp": int(time.time()) - 10})
+
+    claims = get_token_claims(token, "id_token", jwks, silent_if_expired=True)
+
+    assert claims is not None
+    assert claims["sub"] == "user-1"
+
+
+def test_invalid_token_type_raises_value_error() -> None:
+    key, jwks = _key_and_jwks()
+    token = _sign(key, {"sub": "user-1", "exp": int(time.time()) + 3600})
+
+    with pytest.raises(ValueError):
+        get_token_claims(token, "bogus", jwks)  # type: ignore[arg-type]


### PR DESCRIPTION
## What

Migrate the JOSE/JWT surface from `authlib.jose` / `authlib.oidc.core` to `joserfc`. Stops the `AuthlibDeprecationWarning: authlib.jose module is deprecated` that authlib 1.7+ prints on CLI startup, and removes the structural blocker to a future authlib 1.7 bump.

Also raises the `Authlib` floor to `>=1.6.12,<2.0`: per Safety's vulnerability database, `1.2.0`–`1.6.11` are insecure and `1.6.12` is the first secure release. Lockfile changes are out of scope (`uv.lock` is gitignored in this repo).

## Changes

- `safety/utils/tokens.py` — `get_token_claims` now returns the joserfc `Token` (`Token | None`); read the payload via `.claims`. Decode path: `KeySet.import_key_set(jwks)` → `jwt.decode(..., algorithms=["RS256","PS256"])` → per-call `JWTClaimsRegistry().validate(...)`. The `["RS256","PS256"]` allowlist blocks the HS* alg-confusion path. `silent_if_expired` semantics unchanged.
- `safety/auth/oauth2.py` — drop unused `CodeIDToken` import; `get_claims_for` now returns `Token | None`.
- `safety/auth/main.py` — import `ExpiredTokenError` from `joserfc.errors`; `raise ExpiredTokenError("exp")` (joserfc requires the `claim` positional arg); `get_id_token_claims` returns `decoded.claims`, so `is_email_verified` still receives a dict.
- `safety/config/auth.py`, `safety/auth/cli.py` — read claims via `.claims` and guard with `is None` (a `Token` is always truthy).
- `pyproject.toml` — add `joserfc>=1.6.8` (fixes GHSA-5jhw-7jv7-qcqq padded-JWT malleability; also the last release supporting Python 3.9, so 3.9 resolves to 1.6.8 and 3.10+ to 1.7.4, both secure). Raise `Authlib>=1.2.0` → `>=1.6.12,<2.0` (security floor).

## Test plan

- [x] `pytest tests/auth tests/config tests/utils/test_tokens.py` — 354 passed, 1 skipped, 1 xfailed
- [x] Runtime check: real RSA JWKS + signed JWT through `get_token_claims` — valid decode, expired-silent returns claims, expired-non-silent raises `ExpiredTokenError`, bad `token_type` raises `ValueError`
- [x] Imports clean under `python -W error::DeprecationWarning` with authlib 1.7.2 installed (deprecation gone)
- [x] No residual `authlib.jose` / `authlib.oidc` imports in `safety/`
- [x] Authlib `1.6.12` reported secure; `1.2.0` / `1.6.11` insecure (Safety vuln DB)
- [x] CI passes


