### PR TITLE
fix(deps): raise Authlib floor to >=1.6.12 (security)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-  "Authlib>=1.2.0",
+  "Authlib>=1.6.12,<2.0",
   "Click>=8.0.2",
   "dparse>=0.6.4",
   "filelock>=3.16.1,<4.0",


### PR DESCRIPTION
## Symptom
The declared `Authlib` floor (`>=1.2.0`) permits versions that Safety's vulnerability database flags as insecure.

## Root cause
Authlib `1.2.0`–`1.6.11` are insecure; `1.6.12` is the first secure release. The lower bound predates that fix, so a resolver constrained to older Authlib can select a vulnerable version.

## Fix
Raise the constraint to `Authlib>=1.6.12,<2.0`. The `<2.0` cap avoids pulling an unvetted Authlib 2.0.

## Verification
- [ ] `Authlib==1.6.12` reports secure; `1.2.0` and `1.6.11` report insecure
- [ ] `safety auth status` works on Authlib 1.6.12+
- [ ] CI matrix green
