### PR TITLE
chore(deps): bump safety-schemas 0.0.19 → 0.0.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "certifi",
   "tenacity>=8.1.0",
   "ruamel.yaml>=0.17.21",
-  "safety-schemas==0.0.19",
+  "safety-schemas==0.0.20",
   "typer>=0.16.0,<0.26.0",
   "typing-extensions>=4.7.1",
   "nltk>=3.9",


### PR DESCRIPTION
safety-schemas 0.0.20 adds the `ai-installation` block to the v3.0 Config schema (pyupio/safety_schemas#44).

The v3.0 models reject unknown keys, and `download_policy` parses the raw cloud policy with them — so a CLI on 0.0.19 hard-fails the scan the moment an org policy carries the new block. This bump lets releases from here on parse such policies. A policy without the block parses unchanged.

Note for rollout: this protects future releases only — already-installed CLIs keep their vendored 0.0.19 and still fail on a policy carrying the block. Serving-side handling for old clients is a separate platform concern.