### PR TITLE
Add test coverage for safety/emoji.py

### DIFF
--- a/tests/test_emoji.py
+++ b/tests/test_emoji.py
@@ -1,0 +1,67 @@
+from safety.emoji import (
+    load_emoji,
+    process_custom_emojis,
+    process_rich_emojis_fallback,
+)
+
+
+class TestProcessCustomEmojis:
+    def test_non_string_input_is_unchanged(self):
+        assert process_custom_emojis(None) is None
+        assert process_custom_emojis(123) == 123
+
+    def test_text_without_custom_icons_is_unchanged(self):
+        text = "Just a plain message with no icons"
+        assert process_custom_emojis(text) == text
+
+    def test_known_icons_use_unicode_by_default(self):
+        assert process_custom_emojis(":icon_check:") == "✓"
+        assert process_custom_emojis(":icon_warning:") == "⚠️"
+        assert process_custom_emojis(":icon_info:") == "ℹ️"
+
+    def test_known_icons_use_ascii_fallback(self):
+        assert process_custom_emojis(":icon_check:", use_ascii=True) == "+"
+        assert process_custom_emojis(":icon_warning:", use_ascii=True) == "!"
+        assert process_custom_emojis(":icon_info:", use_ascii=True) == "i"
+
+    def test_unknown_icons_are_left_unchanged(self):
+        text = ":icon_does_not_exist:"
+        assert process_custom_emojis(text) == text
+
+    def test_multiple_icons_are_replaced(self):
+        text = "Status: :icon_check: Warning: :icon_warning:"
+        assert process_custom_emojis(text) == "Status: ✓ Warning: ⚠️"
+
+
+class TestProcessRichEmojisFallback:
+    def test_text_without_emoji_codes_is_unchanged(self):
+        text = "Just a plain message"
+        assert process_rich_emojis_fallback(text) == text
+
+    def test_known_emojis_use_ascii_fallback(self):
+        assert process_rich_emojis_fallback(":rocket:") == ">>"
+        assert process_rich_emojis_fallback(":white_check_mark:") == "+"
+        assert process_rich_emojis_fallback(":lock:") == "[LOCK]"
+
+    def test_unknown_emojis_are_left_unchanged(self):
+        text = ":unknown_emoji:"
+        assert process_rich_emojis_fallback(text) == text
+
+    def test_multiple_emojis_are_replaced(self):
+        text = "Launching :rocket: with :lock: enabled"
+        assert process_rich_emojis_fallback(text) == "Launching >> with [LOCK] enabled"
+
+
+class TestLoadEmoji:
+    def test_empty_string_is_unchanged(self):
+        assert load_emoji("") == ""
+
+    def test_custom_icons_are_processed_by_default(self):
+        assert load_emoji(":icon_check:") == "✓"
+
+    def test_rich_emojis_are_left_for_rich_by_default(self):
+        assert load_emoji(":rocket:") == ":rocket:"
+
+    def test_ascii_mode_processes_both_emoji_types(self):
+        text = ":icon_check: Launching :rocket:"
+        assert load_emoji(text, use_ascii=True) == "+ Launching >>"


### PR DESCRIPTION
## Description
`safety/emoji.py` had no test coverage at all — three pure functions (`process_custom_emojis`, `process_rich_emojis_fallback`, `load_emoji`) handling the custom `:icon_*:` namespace and ASCII fallbacks for environments that can't render emoji, with zero tests exercising any of it. Added a full test suite for the module.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): Test coverage addition

## Related Issues
Related to #573

## Testing
- [x] Tests added or updated
- [ ] No tests required

Added `tests/test_emoji.py` with 14 tests covering: known icon/emoji codes replaced correctly (both unicode and ASCII fallback paths), unknown codes left untouched rather than stripped or mis-replaced, non-string input handled gracefully, multiple codes in one string, and the `load_emoji()` branching behavior specifically — Rich emoji codes are only touched when `use_ascii=True`, verified that stays true rather than assumed.

Ran the full suite (`pytest -q`): 885 passed, 14 skipped, 1 pre-existing unrelated flake in `tests/auth/test_status.py` (a timing assertion, `duration_ms > 0`, unrelated to this change).

## Checklist
- [x] Code is well-documented
- [ ] Changelog is updated (if needed)
- [x] No sensitive information (e.g., keys, credentials) is included in the code
- [x] All PR feedback is addressed

## Additional Notes
Picked this up via the general test-coverage issue (#573), which asks contributors to find an untested area and link back — `emoji.py` had no matching test file in `tests/`.
