### PR TITLE
fix(auth): tolerate clock skew and catch joserfc expiry errors

### DIFF
--- a/safety/utils/tokens.py
+++ b/safety/utils/tokens.py
@@ -20,6 +20,12 @@ logger = logging.getLogger(__name__)
 # JWKS public key) even if a symmetric key is ever added to the JWKS.
 _ALLOWED_ALGORITHMS = ["RS256", "PS256"]
 
+# Tolerance, in seconds, for clock skew between this machine and the token
+# issuer when validating iat/exp/nbf. Without this, a token issued even a
+# few seconds ago can fail validation as "issued in the future" on a
+# machine whose clock is slightly behind the issuer's.
+_CLAIMS_LEEWAY_SECONDS = 60
+
 
 def get_token_claims(
     token: str,
@@ -55,7 +61,7 @@ def get_token_claims(
     try:
         key_set = KeySet.import_key_set(jwks)  # type: ignore
         decoded = jwt.decode(token, key_set, algorithms=_ALLOWED_ALGORITHMS)
-        jwt.JWTClaimsRegistry().validate(decoded.claims)
+        jwt.JWTClaimsRegistry(leeway=_CLAIMS_LEEWAY_SECONDS).validate(decoded.claims)
     except ExpiredTokenError:
         if not silent_if_expired:
             raise

--- a/safety/utils/tokens.py
+++ b/safety/utils/tokens.py
@@ -2,13 +2,32 @@
 Token validation utilities shared across the application.
 """
 
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, Literal, Optional, Tuple, Type
 import logging
 
 from authlib.oidc.core import CodeIDToken
 from authlib.jose import jwt
 from authlib.jose.errors import ExpiredTokenError
 
+# Authlib >= 1.7 implements authlib.jose on top of joserfc and lets
+# joserfc's own exceptions propagate instead of the authlib.jose ones,
+# so ExpiredTokenError alone no longer catches an expired token on those
+# versions. joserfc is a transitive dependency there, but not on older
+# authlib releases, so only rely on it when it's actually importable.
+try:
+    from joserfc.errors import ExpiredTokenError as JoseRFCExpiredTokenError
+
+    _EXPIRED_TOKEN_ERRORS: Tuple[Type[Exception], ...] = (
+        ExpiredTokenError,
+        JoseRFCExpiredTokenError,
+    )
+except ImportError:  # pragma: no cover - depends on installed authlib version
+    _EXPIRED_TOKEN_ERRORS = (ExpiredTokenError,)
+
+# Tolerance, in seconds, for clock skew between this machine and the token
+# issuer when validating iat/exp/nbf. Matches the leeway authlib's own
+# OAuth client integrations (Flask, Django, httpx) apply by default.
+TOKEN_LEEWAY_SECONDS = 60
 
 logger = logging.getLogger(__name__)
 
@@ -42,8 +61,8 @@ def get_token_claims(
 
     try:
         claims = jwt.decode(token, jwks, claims_cls=CodeIDToken)  # type: ignore
-        claims.validate()
-    except ExpiredTokenError as e:
+        claims.validate(leeway=TOKEN_LEEWAY_SECONDS)
+    except _EXPIRED_TOKEN_ERRORS as e:
         if not silent_if_expired:
             raise e
 

--- a/tests/utils/test_tokens.py
+++ b/tests/utils/test_tokens.py
@@ -1,0 +1,52 @@
+import time
+
+import pytest
+from authlib.jose import jwt as authlib_jwt
+
+from safety.utils.tokens import _EXPIRED_TOKEN_ERRORS, get_token_claims
+
+SECRET = "test-secret"
+
+
+def _make_token(iat_offset: int = 0, exp_offset: int = 3600) -> str:
+    now = int(time.time())
+    header = {"alg": "HS256"}
+    payload = {
+        "iss": "https://safetycli.com",
+        "sub": "user-123",
+        "aud": "safety-cli",
+        "exp": now + exp_offset,
+        "iat": now + iat_offset,
+        "nonce": "n",
+    }
+    return authlib_jwt.encode(header, payload, SECRET).decode("utf-8")
+
+
+class TestGetTokenClaims:
+    def test_accepts_token_issued_slightly_in_the_future(self):
+        # A few seconds of clock skew between the client and the token
+        # issuer is normal and shouldn't reject an otherwise valid token.
+        token = _make_token(iat_offset=5)
+        claims = get_token_claims(token, "id_token", SECRET)
+        assert claims is not None
+        assert claims["sub"] == "user-123"
+
+    def test_rejects_token_issued_far_in_the_future(self):
+        token = _make_token(iat_offset=600)
+        with pytest.raises(Exception, match="future"):
+            get_token_claims(token, "id_token", SECRET)
+
+    def test_silent_if_expired_swallows_an_expired_token(self):
+        # Decoding still succeeds; only the raised validation error is
+        # swallowed, so the (unvalidated) claims are still returned.
+        token = _make_token(iat_offset=-7200, exp_offset=-3600)
+        claims = get_token_claims(
+            token, "access_token", SECRET, silent_if_expired=True
+        )
+        assert claims is not None
+        assert claims["sub"] == "user-123"
+
+    def test_expired_token_raises_by_default(self):
+        token = _make_token(iat_offset=-7200, exp_offset=-3600)
+        with pytest.raises(_EXPIRED_TOKEN_ERRORS):
+            get_token_claims(token, "access_token", SECRET)

--- a/tests/utils/test_tokens.py
+++ b/tests/utils/test_tokens.py
@@ -43,7 +43,9 @@ def test_valid_token_returns_claims() -> None:
 
 def test_expired_token_raises_when_not_silent() -> None:
     key, jwks = _key_and_jwks()
-    token = _sign(key, {"sub": "user-1", "exp": int(time.time()) - 10})
+    # Well past the leeway, so this is genuinely expired rather than
+    # within the clock-skew grace period.
+    token = _sign(key, {"sub": "user-1", "exp": int(time.time()) - 3600})
 
     # A JWTClaimsRegistry is constructed per call, so it reads the clock at
     # validate time and an already-expired token is rejected.
@@ -53,12 +55,36 @@ def test_expired_token_raises_when_not_silent() -> None:
 
 def test_expired_token_returns_claims_when_silent() -> None:
     key, jwks = _key_and_jwks()
-    token = _sign(key, {"sub": "user-1", "exp": int(time.time()) - 10})
+    # Well past the leeway, so this is genuinely expired rather than
+    # within the clock-skew grace period.
+    token = _sign(key, {"sub": "user-1", "exp": int(time.time()) - 3600})
 
     decoded = get_token_claims(token, "id_token", jwks, silent_if_expired=True)
 
     assert decoded is not None
     assert decoded.claims["sub"] == "user-1"
+
+
+def test_token_issued_slightly_in_the_future_is_accepted() -> None:
+    # A few seconds of clock skew between this machine and the token
+    # issuer is normal and shouldn't reject an otherwise valid token.
+    key, jwks = _key_and_jwks()
+    now = int(time.time())
+    token = _sign(key, {"sub": "user-1", "exp": now + 3600, "iat": now + 5})
+
+    decoded = get_token_claims(token, "id_token", jwks)
+
+    assert decoded is not None
+    assert decoded.claims["sub"] == "user-1"
+
+
+def test_token_issued_far_in_the_future_is_rejected() -> None:
+    key, jwks = _key_and_jwks()
+    now = int(time.time())
+    token = _sign(key, {"sub": "user-1", "exp": now + 7200, "iat": now + 600})
+
+    with pytest.raises(Exception, match="future"):
+        get_token_claims(token, "id_token", jwks)
 
 
 def test_invalid_token_type_raises_value_error() -> None:


### PR DESCRIPTION
Fixes #850.

get_token_claims() validates iat/exp/nbf with zero leeway, so a few seconds of clock drift between the client and the token issuer gets a valid token rejected as "issued in the future".

Separately, Authlib >= 1.7 implements authlib.jose on top of joserfc and lets joserfc's own exceptions propagate instead of the authlib.jose ones. The except clause only caught authlib.jose.errors.ExpiredTokenError, so on those Authlib versions silent_if_expired never actually worked, and an expired access token raised instead of being handled quietly.

Added a 60 second leeway, matching what authlib's own OAuth client integrations (Flask, Django, httpx) use by default. Now catching both exception classes too, falling back to just the authlib.jose one on older Authlib versions that don't ship joserfc.

Added tests covering: a token issued a few seconds in the future is accepted, one issued far in the future is still rejected, an expired token is swallowed when silent_if_expired is set, and raised when it isn't. Ran the auth, config, and utils test suites (264 passing, 2 pre-existing unrelated failures reproduced identically on main).