### PR TITLE
fix(deps): drop nltk, vendor its edit_distance

### DIFF
--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSES/NLTK-NOTICE.md
+++ b/LICENSES/NLTK-NOTICE.md
@@ -1,0 +1,16 @@
+# NLTK third-party notice
+
+`safety/tool/_vendor/nltk_distance.py` contains the edit-distance portion of
+NLTK's `nltk/metrics/distance.py` from v3.10.3.
+
+- Copyright (C) 2001-2026 NLTK Project
+- License: Apache License 2.0 (`Apache-2.0.txt`)
+- Source: https://github.com/nltk/nltk/blob/v3.10.3/nltk/metrics/distance.py
+- Commit: `303f6e2ba8e4548a5f54fd65d86bb5c9a949f1db`
+- Upstream file SHA-256: `caa1d4f040d2468d4b6e9ba75a7c0e5bf88cd740656f96e7df5dc40184df288b`
+
+Safety CLI extracted the edit-distance implementation and removed unrelated
+metrics and imports. Comments, docstrings and error messages that named the
+removed metrics or upstream module paths were rewritten to describe only what
+is vendored here. The original copyright and author header is retained in the
+vendored source file, and the file states the modifications inline.

--- a/LICENSES/NOTICE.md
+++ b/LICENSES/NOTICE.md
@@ -18,12 +18,10 @@
 | httpx | 0.28.1 | BSD-3-Clause |
 | idna | 3.10 | BSD License |
 | jinja2 | 3.1.6 | BSD License |
-| joblib | 1.4.2 | BSD 3-Clause |
 | markdown-it-py | 3.0.0 | MIT License |
 | markupsafe | 2.1.5 | BSD-3-Clause |
 | marshmallow | 3.22.0 | MIT License |
 | mdurl | 0.1.2 | MIT License |
-| nltk | 3.9.1 | Apache License, Version 2.0 |
 | packaging | 25.0 | Apache Software License |
 | pip | 23.0.1 | MIT |
 | psutil | 6.1.1 | BSD-3-Clause |
@@ -31,7 +29,6 @@
 | pydantic | 2.9.2 | MIT |
 | pydantic-core | 2.23.4 | MIT |
 | pygments | 2.19.1 | BSD-2-Clause |
-| regex | 2024.11.6 | Apache Software License |
 | requests | 2.32.3 | Apache-2.0 |
 | rich | 14.0.0 | MIT |
 | ruamel-yaml | 0.18.10 | MIT license |
@@ -43,7 +40,6 @@
 | tenacity | 9.0.0 | Apache 2.0 |
 | tomli | 2.2.1 | MIT License |
 | tomlkit | 0.13.2 | MIT |
-| tqdm | 4.67.1 | MPL-2.0 AND MIT |
 | typer | 0.15.2 | MIT License |
 | typing-extensions | 4.13.2 | PSF-2.0 |
 | urllib3 | 2.2.3 | MIT License |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
   "safety-schemas==0.0.19",
   "typer>=0.16.0,<0.26.0",
   "typing-extensions>=4.7.1",
-  "nltk>=3.9",
   "tomli; python_version < '3.11'",
   "tomlkit",
   "truststore>=0.10.4; python_version >= '3.10'",

--- a/safety/tool/_vendor/__init__.py
+++ b/safety/tool/_vendor/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored third-party helpers."""

--- a/safety/tool/_vendor/nltk_distance.py
+++ b/safety/tool/_vendor/nltk_distance.py
@@ -1,0 +1,139 @@
+# Natural Language Toolkit: Distance Metrics
+#
+# Copyright (C) 2001-2026 NLTK Project
+# Author: Edward Loper <edloper@gmail.com>
+#         Steven Bird <stevenbird1@gmail.com>
+#         Tom Lippincott <tom@cs.columbia.edu>
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSES/Apache-2.0.txt.
+#
+# Modified by Safety CLI on 2026-09-02:
+# - Extracted the edit-distance implementation from NLTK v3.10.3.
+# - Removed unrelated metrics and imports.
+# - Repointed the license reference, and rewrote the
+#   MAX_DISTANCE_INPUT_LEN comment, the _check_distance_input_len
+#   docstring and its error message, so they describe only the
+#   edit_distance vendored here rather than metrics left behind.
+# Source: https://github.com/nltk/nltk/blob/v3.10.3/nltk/metrics/distance.py
+
+#: Maximum input length accepted by :func:`edit_distance`, which is O(n*m) in
+#: both time and memory (it builds a full ``(n+1)x(m+1)`` DP matrix) over two
+#: untrusted strings. An unbounded length is therefore a CPU/memory DoS
+#: (CWE-407, CWE-400): ``edit_distance("a"*40000, "b"*40000)`` allocates tens
+#: of GB and runs for hours. A real distance query is short; raise this if you
+#: genuinely need to compare very long, trusted strings.
+MAX_DISTANCE_INPUT_LEN = 2000
+
+
+def _check_distance_input_len(s1, s2, func_name):
+    """Reject oversized inputs to the O(n*m) distance function."""
+    longest = max(len(s1), len(s2))
+    if longest > MAX_DISTANCE_INPUT_LEN:
+        raise ValueError(
+            f"{func_name}: input length {longest} exceeds MAX_DISTANCE_INPUT_LEN "
+            f"({MAX_DISTANCE_INPUT_LEN}). This function is super-linear in the "
+            "input length over two untrusted strings (CWE-407/CWE-400); a long "
+            "input is a CPU/memory DoS. Raise safety.tool._vendor.nltk_distance."
+            "MAX_DISTANCE_INPUT_LEN if you need to compare longer trusted strings."
+        )
+
+
+def _edit_dist_init(len1, len2):
+    lev = []
+    for i in range(len1):
+        lev.append([0] * len2)  # initialize 2D array to zero
+    for i in range(len1):
+        lev[i][0] = i  # column 0: 0,1,2,3,4,...
+    for j in range(len2):
+        lev[0][j] = j  # row 0: 0,1,2,3,4,...
+    return lev
+
+
+def _last_left_t_init(sigma):
+    return {c: 0 for c in sigma}
+
+
+def _edit_dist_step(
+    lev, i, j, s1, s2, last_left, last_right, substitution_cost=1, transpositions=False
+):
+    c1 = s1[i - 1]
+    c2 = s2[j - 1]
+
+    # skipping a character in s1
+    a = lev[i - 1][j] + 1
+    # skipping a character in s2
+    b = lev[i][j - 1] + 1
+    # substitution
+    c = lev[i - 1][j - 1] + (substitution_cost if c1 != c2 else 0)
+
+    # transposition
+    d = c + 1  # never picked by default
+    if transpositions and last_left > 0 and last_right > 0:
+        d = lev[last_left - 1][last_right - 1] + i - last_left + j - last_right - 1
+
+    # pick the cheapest
+    lev[i][j] = min(a, b, c, d)
+
+
+def edit_distance(s1, s2, substitution_cost=1, transpositions=False):
+    """
+    Calculate the Levenshtein edit-distance between two strings.
+    The edit distance is the number of characters that need to be
+    substituted, inserted, or deleted, to transform s1 into s2.  For
+    example, transforming "rain" to "shine" requires three steps,
+    consisting of two substitutions and one insertion:
+    "rain" -> "sain" -> "shin" -> "shine".  These operations could have
+    been done in other orders, but at least three steps are needed.
+
+    Allows specifying the cost of substitution edits (e.g., "a" -> "b"),
+    because sometimes it makes sense to assign greater penalties to
+    substitutions.
+
+    This also optionally allows transposition edits (e.g., "ab" -> "ba"),
+    though this is disabled by default.
+
+    :param s1, s2: The strings to be analysed
+    :param transpositions: Whether to allow transposition edits
+    :type s1: str
+    :type s2: str
+    :type substitution_cost: int
+    :type transpositions: bool
+    :rtype: int
+    """
+    _check_distance_input_len(s1, s2, "edit_distance")
+    # set up a 2-D array
+    len1 = len(s1)
+    len2 = len(s2)
+    lev = _edit_dist_init(len1 + 1, len2 + 1)
+
+    # retrieve alphabet
+    sigma = set()
+    sigma.update(s1)
+    sigma.update(s2)
+
+    # set up table to remember positions of last seen occurrence in s1
+    last_left_t = _last_left_t_init(sigma)
+
+    # iterate over the array
+    # i and j start from 1 and not 0 to stay close to the wikipedia pseudo-code
+    # see https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance
+    for i in range(1, len1 + 1):
+        last_right_buf = 0
+        for j in range(1, len2 + 1):
+            last_left = last_left_t[s2[j - 1]]
+            last_right = last_right_buf
+            if s1[i - 1] == s2[j - 1]:
+                last_right_buf = j
+            _edit_dist_step(
+                lev,
+                i,
+                j,
+                s1,
+                s2,
+                last_left,
+                last_right,
+                substitution_cost=substitution_cost,
+                transpositions=transpositions,
+            )
+        last_left_t[s1[i - 1]] = i
+    return lev[len1][len2]

--- a/safety/tool/typosquatting.py
+++ b/safety/tool/typosquatting.py
@@ -3,11 +3,11 @@ Typosquatting detection for various tools.
 """
 
 import logging
-import nltk
 from typing import Tuple
 
 from safety.console import main_console as console
 from rich.prompt import Prompt
+from ._vendor.nltk_distance import edit_distance
 from .intents import CommandToolIntention, ToolIntentionType
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ class TyposquattingProtection:
         for pkg in self.popular_packages:
             if (
                 abs(len(pkg) - len(package_name)) <= max_edit_distance
-                and nltk.edit_distance(pkg, package_name) <= max_edit_distance
+                and edit_distance(pkg, package_name) <= max_edit_distance
             ):
                 return (False, pkg)
 

--- a/safety/tool/typosquatting.py
+++ b/safety/tool/typosquatting.py
@@ -3,6 +3,7 @@ Typosquatting detection for various tools.
 """
 
 import logging
+from collections.abc import Sequence
 
 from rich.prompt import Prompt
 
@@ -19,7 +20,7 @@ class TyposquattingProtection:
     Base class for typosquatting detection.
     """
 
-    def __init__(self, popular_packages: tuple[str]):
+    def __init__(self, popular_packages: Sequence[str]):
         self.popular_packages = popular_packages
 
     def check_package(self, package_name: str) -> tuple[bool, str]:

--- a/safety/tool/typosquatting.py
+++ b/safety/tool/typosquatting.py
@@ -3,10 +3,11 @@ Typosquatting detection for various tools.
 """
 
 import logging
-from typing import Tuple
+
+from rich.prompt import Prompt
 
 from safety.console import main_console as console
-from rich.prompt import Prompt
+
 from ._vendor.nltk_distance import edit_distance
 from .intents import CommandToolIntention, ToolIntentionType
 
@@ -18,10 +19,10 @@ class TyposquattingProtection:
     Base class for typosquatting detection.
     """
 
-    def __init__(self, popular_packages: Tuple[str]):
+    def __init__(self, popular_packages: tuple[str]):
         self.popular_packages = popular_packages
 
-    def check_package(self, package_name: str) -> Tuple[bool, str]:
+    def check_package(self, package_name: str) -> tuple[bool, str]:
         """
         Check if a package name is likely to be a typosquatting attempt.
 

--- a/tests/tool/test_typosquatting.py
+++ b/tests/tool/test_typosquatting.py
@@ -4,13 +4,13 @@ Test suite for TyposquattingProtection functionality.
 
 import ast
 from pathlib import Path
-
-import pytest
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from safety.tool import typosquatting
-from safety.tool.typosquatting import TyposquattingProtection
 from safety.tool.intents import CommandToolIntention, ToolIntentionType
+from safety.tool.typosquatting import TyposquattingProtection
 
 
 @pytest.mark.unit

--- a/tests/tool/test_typosquatting.py
+++ b/tests/tool/test_typosquatting.py
@@ -2,9 +2,13 @@
 Test suite for TyposquattingProtection functionality.
 """
 
+import ast
+from pathlib import Path
+
 import pytest
 from unittest.mock import MagicMock, patch
 
+from safety.tool import typosquatting
 from safety.tool.typosquatting import TyposquattingProtection
 from safety.tool.intents import CommandToolIntention, ToolIntentionType
 
@@ -217,19 +221,25 @@ class TestTyposquattingProtection:
         assert is_valid is False
         assert suggestion == "requests"
 
-    def test_nltk_edit_distance_calculation(self):
-        """Test that NLTK edit distance is used correctly"""
-        # Test known edit distances
-        with patch(
-            "safety.tool.typosquatting.nltk.edit_distance"
-        ) as mock_edit_distance:
-            mock_edit_distance.return_value = 1
+    def test_short_transposition_is_not_within_edit_distance_threshold(self):
+        """A transposition counts as two edits with the default algorithm."""
+        protection = TyposquattingProtection(["ab"])
 
-            is_valid, suggestion = self.protection.check_package("reqests")
+        is_valid, suggestion = protection.check_package("ba")
 
-            # Should have called nltk.edit_distance
-            mock_edit_distance.assert_called()
-            assert is_valid is False
+        assert is_valid is True
+        assert suggestion == "ba"
+
+    def test_has_no_nltk_import(self):
+        """The vendored edit distance must not be swapped back for the NLTK package."""
+        tree = ast.parse(Path(typosquatting.__file__).read_text())
+        imported_roots = {
+            ast.unparse(node).split()[1].split(".")[0]
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+        }
+
+        assert "nltk" not in imported_roots
 
     @pytest.mark.parametrize(
         "package_name,expected_valid,expected_suggestion",


### PR DESCRIPTION
## Description

`nltk` was a full dependency pulled in for a single call, `nltk.edit_distance`, used by typosquatting detection. This vendors the edit-distance implementation from NLTK v3.10.3 into `safety/tool/_vendor/nltk_distance.py` and drops the dependency.

- Removes `nltk` and its exclusive transitive deps (`joblib`, `regex`, `tqdm`, `cloudpickle`, `defusedxml`) from the install tree.
- NLTK is Apache-2.0, so its license text ships as `LICENSES/Apache-2.0.txt` and the attribution plus modification record as `LICENSES/NLTK-NOTICE.md`. Both land in the wheel under `dist-info/licenses/`.
- No executable logic differs from upstream. Only the extraction, the license pointer, and comments are changed.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): dependency removal

## Related Issues

Ports `pyupio/safety-endpoint#204`.

## Testing

- [x] Tests added or updated
- [ ] No tests required

The mock-based `nltk.edit_distance` test is replaced by a behavior test plus an AST check that the `nltk` import cannot be reintroduced.

- [x] `tests/tool/test_typosquatting.py`: 25 passed
- [x] Full suite: 884 passed. One pre-existing failure, `test_enroll_invalid_key_rejected`, which fails identically on clean `main`
- [x] Vendored file diffed against upstream NLTK v3.10.3: every hunk is a comment, docstring, or one string literal
- [x] SHA-256 of the upstream source matches the value recorded in `NLTK-NOTICE.md`, and the commit recorded there is the one tag `v3.10.3` points to
- [x] `ruff check` and `ruff format --check` clean
- [x] Built wheel carries `License-Expression: MIT` and all four `LICENSES/*` files as `License-File`

## Checklist

- [x] Code is well-documented
- [x] Changelog is updated (if needed): generated by `cz bump`, no manual entry
- [x] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes

`LICENSES/NOTICE.md` drops its `nltk`, `joblib`, `regex` and `tqdm` rows, since those packages leave the dependency tree. Its remaining rows are stale for unrelated reasons (`authlib`, `cryptography`, `safety-schemas`) and are left for a separate refresh.

Comments, a docstring and an error message inside the vendored file named `edit_distance_align`, `jaro_similarity` and `nltk.metrics.distance`, none of which exist in this tree. They now describe only the vendored `edit_distance`, and the file records that edit inline to satisfy Apache-2.0 section 4(b).
