### PR TITLE
fix(auth): require registered claims when validating JWTs

### DIFF
--- a/safety/utils/tokens.py
+++ b/safety/utils/tokens.py
@@ -21,6 +21,25 @@ logger = logging.getLogger(__name__)
 _ALLOWED_ALGORITHMS = ["RS256", "PS256"]
 
 
+def _required_claims_registry() -> jwt.JWTClaimsRegistry:
+    """A registry that requires the registered claims to be present.
+
+    JWTClaimsRegistry requires nothing by default and validates only the
+    claims a token happens to carry. Without this a signature-valid token
+    with no "exp" has nothing for the expiry check to compare against, so it
+    never fails and is accepted forever. These are the claims authlib's
+    CodeIDToken required before the joserfc migration, applied to both token
+    types as it was then, so this is the contract 3.8.1 shipped with.
+    """
+    return jwt.JWTClaimsRegistry(
+        iss={"essential": True},
+        sub={"essential": True},
+        aud={"essential": True},
+        iat={"essential": True},
+        exp={"essential": True},
+    )
+
+
 def get_token_claims(
     token: str,
     token_type: Literal["access_token", "id_token"],
@@ -45,6 +64,8 @@ def get_token_claims(
 
     Raises:
         ValueError: If token_type is invalid
+        MissingClaimError: If the token omits a registered claim. This is
+            never silenced; silent_if_expired only forgives expiry.
         ExpiredTokenError: If token is expired and silent_if_expired is False
     """
     if token_type not in ("access_token", "id_token"):
@@ -55,7 +76,7 @@ def get_token_claims(
     try:
         key_set = KeySet.import_key_set(jwks)  # type: ignore
         decoded = jwt.decode(token, key_set, algorithms=_ALLOWED_ALGORITHMS)
-        jwt.JWTClaimsRegistry().validate(decoded.claims)
+        _required_claims_registry().validate(decoded.claims)
     except ExpiredTokenError:
         if not silent_if_expired:
             raise

--- a/tests/utils/test_tokens.py
+++ b/tests/utils/test_tokens.py
@@ -13,7 +13,11 @@ from typing import Any
 
 import pytest
 from joserfc import jwt as joserfc_jwt
-from joserfc.errors import ExpiredTokenError, UnsupportedAlgorithmError
+from joserfc.errors import (
+    ExpiredTokenError,
+    MissingClaimError,
+    UnsupportedAlgorithmError,
+)
 from joserfc.jwk import OctKey, RSAKey
 
 from safety.utils.tokens import get_token_claims
@@ -30,9 +34,27 @@ def _sign(key: RSAKey, claims: dict[str, Any]) -> str:
     return joserfc_jwt.encode(_HEADER, claims, key)
 
 
+def _claims(**overrides: Any) -> dict[str, Any]:
+    """A complete claim set, shaped like what the IdP actually issues.
+
+    get_token_claims requires the OIDC registered claims, so a test about
+    something else (expiry, algorithm) still has to hand over a full set or
+    it fails for the wrong reason.
+    """
+    now = int(time.time())
+    return {
+        "iss": "https://auth.safetycli.com/",
+        "sub": "user-1",
+        "aud": "safety-cli",
+        "iat": now,
+        "exp": now + 3600,
+        **overrides,
+    }
+
+
 def test_valid_token_returns_claims() -> None:
     key, jwks = _key_and_jwks()
-    token = _sign(key, {"sub": "user-1", "org": "acme", "exp": int(time.time()) + 3600})
+    token = _sign(key, _claims(org="acme"))
 
     decoded = get_token_claims(token, "id_token", jwks)
 
@@ -43,7 +65,7 @@ def test_valid_token_returns_claims() -> None:
 
 def test_expired_token_raises_when_not_silent() -> None:
     key, jwks = _key_and_jwks()
-    token = _sign(key, {"sub": "user-1", "exp": int(time.time()) - 10})
+    token = _sign(key, _claims(exp=int(time.time()) - 10))
 
     # A JWTClaimsRegistry is constructed per call, so it reads the clock at
     # validate time and an already-expired token is rejected.
@@ -53,7 +75,7 @@ def test_expired_token_raises_when_not_silent() -> None:
 
 def test_expired_token_returns_claims_when_silent() -> None:
     key, jwks = _key_and_jwks()
-    token = _sign(key, {"sub": "user-1", "exp": int(time.time()) - 10})
+    token = _sign(key, _claims(exp=int(time.time()) - 10))
 
     decoded = get_token_claims(token, "id_token", jwks, silent_if_expired=True)
 
@@ -63,7 +85,7 @@ def test_expired_token_returns_claims_when_silent() -> None:
 
 def test_invalid_token_type_raises_value_error() -> None:
     key, jwks = _key_and_jwks()
-    token = _sign(key, {"sub": "user-1", "exp": int(time.time()) + 3600})
+    token = _sign(key, _claims())
 
     with pytest.raises(ValueError):
         get_token_claims(token, "bogus", jwks)  # type: ignore[arg-type]
@@ -78,9 +100,38 @@ def test_alg_confusion_hs256_is_rejected() -> None:
         warnings.simplefilter("ignore")  # joserfc warns on RSA-PEM-as-oct-key
         forged = joserfc_jwt.encode(
             {"alg": "HS256", "kid": "test-kid"},
-            {"sub": "attacker", "exp": int(time.time()) + 3600},
+            _claims(sub="attacker"),
             OctKey.import_key(key.as_pem(private=False)),
         )
 
     with pytest.raises(UnsupportedAlgorithmError):
         get_token_claims(forged, "id_token", jwks)
+
+
+@pytest.mark.parametrize("missing", ["iss", "sub", "aud", "iat", "exp"])
+def test_missing_registered_claim_is_rejected(missing: str) -> None:
+    """A correctly signed token still has to carry the registered claims.
+
+    A signature only proves who wrote the token, not that it says what we
+    need it to say. Dropping "exp" is the sharp case: with no expiry claim
+    there is nothing for the expiry check to compare against, so the token
+    would be accepted forever.
+    """
+    key, jwks = _key_and_jwks()
+    claims = _claims()
+    del claims[missing]
+    token = _sign(key, claims)
+
+    with pytest.raises(MissingClaimError):
+        get_token_claims(token, "id_token", jwks)
+
+
+def test_missing_claim_is_not_silenced_by_silent_if_expired() -> None:
+    """silent_if_expired only forgives expiry, never an incomplete token."""
+    key, jwks = _key_and_jwks()
+    claims = _claims()
+    del claims["exp"]
+    token = _sign(key, claims)
+
+    with pytest.raises(MissingClaimError):
+        get_token_claims(token, "id_token", jwks, silent_if_expired=True)


### PR DESCRIPTION
## Description

Found while reviewing `3.8.1..main` ahead of the next release.

#908 (authlib.jose → joserfc) swapped `claims_cls=CodeIDToken` for a bare `jwt.JWTClaimsRegistry()`. `CodeIDToken` required `iss`/`sub`/`aud`/`iat`/`exp` to be present; the bare registry declares nothing essential, so it validates only the claims a token happens to carry. With no `exp`, the expiry check has nothing to compare against, so it never runs and never fails.

**This is not a vulnerability, and not a release blocker.** Signature verification and the RS256/PS256 allowlist are untouched, so a forged token is still rejected. It takes a real, IdP-signed token that is malformed, in one specific shape:

| Token pair | 3.8.1 | main today |
| --- | --- | --- |
| both well-formed | accepted | accepted |
| access_token missing `exp` | rejected | rejected — `AuthConfig.to_token` hand-checks `exp` |
| **id_token missing `exp`, access_token fine** | **rejected** | **accepted, and never refreshed** |
| forged signature | rejected | rejected |

Consequence is bounded to that third row. The id_token feeds identity display (`SafetyContext().account`, org UUID); the access_token, which actually authorizes API calls, keeps its own independent `exp` check and its authlib-driven refresh.

What this is: an unintended regression from a validation contract 3.8.1 shipped. #908 was a library migration, and dropping the required-claims check wasn't part of its intent.

Fix — declare the claims essential:

```python
return jwt.JWTClaimsRegistry(
    iss={"essential": True}, sub={"essential": True}, aud={"essential": True},
    iat={"essential": True}, exp={"essential": True},
)
```

All five rather than just `exp`: 3.8.1 applied `CodeIDToken` unconditionally to both token types, so this restores a contract already running in production instead of asking the IdP for something new.

Blast radius: all three callers (`AuthConfig.to_token`, `get_auth_info`, `_extract_org_uuid_from_jwt`) already sit inside bare `except Exception` handlers, so `MissingClaimError` degrades to discard-token-and-reauth, not a traceback. Machine tokens never reach `get_token_claims`, so enrollment is untouched.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## Related Issues

None.

## Testing

- [x] Tests added or updated
- [ ] No tests required

- `test_missing_registered_claim_is_rejected`, parametrized over all five claims.
- `test_missing_claim_is_not_silenced_by_silent_if_expired` — pins that `silent_if_expired` forgives expiry only. Without it, widening that `except` later would silently reopen this.
- Added a `_claims()` helper and rewired the three existing tests to it, so they no longer fail for the wrong reason.
- Watched all six new cases fail with `DID NOT RAISE MissingClaimError` before implementing.

End-to-end against a real `safety auth login` — see the comment below for the method and output.

Verification:

- [x] Full suite, py3.11 / Authlib 1.7.2 / joserfc 1.7.4: 892 passed, 7 skipped, 1 failed
- [x] The one failure is `tests/integration/test_enroll.py::test_enroll_invalid_key_rejected`, which fails identically on pristine `main` (env-dependent, unrelated)
- [x] Pinned floor joserfc 1.6.8 / py3.9: complete token accepted, no-`exp` token raises `MissingClaimError`
- [x] `ruff check`, `ruff format --check`, `pyright` clean

## Checklist

- [x] Code is well-documented
- [ ] Changelog is updated (if needed) — auto-generated by commitizen at bump
- [x] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes

Two things from the same review, both out of scope here:

- CI on `main` is currently red (run 33822577974). It's the flaky `test_concurrent_read_and_write_dont_corrupt` multiprocessing race, failing on scheduled runs since 2026-08-27, before any of the post-3.8.1 commits. Worth a rerun before tagging.
- #912 overlaps this file. Its joserfc-exception half is already handled by #908. Its zero-leeway `iat` half is real but is **not** a regression: 3.8.1 rejected future-`iat` tokens identically. That's still #850.
