### PR TITLE
fix(deps): cap Authlib below 1.8 to avoid the httpx2 timeout crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-  "Authlib>=1.6.12,<2.0",
+  "Authlib>=1.6.12,<1.8",
   "joserfc>=1.6.8",
   "Click>=8.0.2",
   "dparse>=0.6.4",


### PR DESCRIPTION
## Description

Found while checking the resolved dependency set ahead of the next release.

There is no lockfile, so a fresh `pip install safety` resolves **Authlib 1.8.0**. 1.8.0 added a shim that prefers `httpx2` over `httpx` whenever httpx2 is importable:

```python
# authlib/integrations/httpx_client/_compat.py
try:
    import httpx2
except ImportError:
    import httpx as httpx2
    deprecate("The httpx module is deprecated; please use httpx2 instead.")
```

Safety builds its clients with an **old-httpx** `Timeout` object (`safety/platform/client.py:197`, `safety/utils/tls_probe.py:166`). When authlib routes through httpx2, that object reaches `httpcore2`, which wants a number:

```
$ safety auth status
  ...
  File ".../httpcore2/_backends/sync.py", line 204, in connect_tcp
    sock = socket.create_connection(
  File ".../socket.py", line 845, in create_connection
    sock.settimeout(timeout)
TypeError: 'Timeout' object cannot be interpreted as an integer
```

| | |
| --- | --- |
| **Trigger** | `httpx2` present anywhere in the environment, plus Authlib ≥ 1.8.0 |
| **Effect** | every network-touching command dies with an unhandled `TypeError` |
| **User error required** | none — safety often shares an env with a project's own dependencies |
| **Scope** | the shim is in **1.8.0 only**; 1.6.12 and 1.7.2 are clean (checked both) |
| **Regression?** | **No.** 3.8.1 shipped `Authlib>=1.2.0` uncapped and is equally exposed |

## Fix

Cap below 1.8. This keeps the security floor introduced in #908, and also removes the `AuthlibDeprecationWarning` that 1.8.0 prints to stderr on *every* invocation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## Related Issues

None.

## Testing

- [ ] Tests added or updated
- [x] No tests required

A dependency cap has no meaningful unit test — the behaviour under test is the resolution itself. Verified by building the wheel and installing it into a clean venv **with `httpx2` deliberately installed**, which is the exact condition that triggers the crash:

```
Authlib   1.7.2      <- capped, no shim
httpx     0.28.1
httpx2    2.12.0     <- present, and now harmless

$ safety --version        # stderr AuthlibDeprecationWarning count: 0
$ safety auth status      # succeeds against the real platform
```

Same environment on `main` (Authlib 1.8.0) raises the `TypeError` above.

Verification:

- [x] Fresh wheel install + `httpx2`: `safety auth status` succeeds; on `main` it crashes
- [x] `AuthlibDeprecationWarning` no longer printed on any invocation
- [x] Full suite on that same capped environment: 886 passed, 7 skipped, 1 failed
- [x] The one failure is `tests/integration/test_enroll.py::test_enroll_invalid_key_rejected`, which fails identically on pristine `main` (env-dependent, unrelated)

## Checklist

- [x] Code is well-documented
- [ ] Changelog is updated (if needed) — auto-generated by commitizen at bump
- [x] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes

**Follow-up worth doing, deliberately not in this PR.** The root cause is that safety passes `httpx.Timeout(...)` rather than a plain number. Changing both call sites to pass the float directly makes safety work under httpx *and* httpx2, which is what would let this cap be lifted:

```diff
-            "timeout": httpx.Timeout(timeout),
+            "timeout": timeout,
```

I tested that patch under Authlib 1.8.0 with httpx2 installed and a full `safety auth login` + `auth status` round-trip succeeded. It is kept out of this PR so the release-unblocking cap stays a one-line review.

Worth pairing that follow-up with a CI cell that installs `httpx2`, since nothing in the current matrix exercises this combination.
