### PR TITLE
fix(config): write auth config atomically instead of truncating in place

### DIFF
--- a/safety/config/auth.py
+++ b/safety/config/auth.py
@@ -5,6 +5,7 @@
 from authlib.oauth2.rfc6749 import OAuth2Token
 from dataclasses import dataclass
 import configparser
+import os
 
 from filelock import FileLock
 from pathlib import Path
@@ -14,6 +15,37 @@ from typing import Any, Dict, Optional, Tuple, cast
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _write_config_atomically(config: configparser.ConfigParser, path: Path) -> None:
+    """Replace the file at `path` with `config` in a single step.
+
+    Writing straight to `path` truncates it before the new contents land.
+    This file holds credentials and `from_storage` reads it without taking
+    the lock, so that window hands an empty file to any concurrent reader,
+    and a write that fails partway through loses the credentials outright.
+
+    Write a sibling temp file and rename over the target instead. `os.replace`
+    is atomic on POSIX and Windows, so a reader sees either the old contents
+    or the new ones.
+    """
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+
+    try:
+        with open(tmp, "w") as configfile:
+            config.write(configfile)
+            configfile.flush()
+            os.fsync(configfile.fileno())
+
+        if path.exists():
+            # `os.replace` keeps the temp file's own mode, so carry the
+            # existing one over rather than widening a tightened config.
+            os.chmod(tmp, path.stat().st_mode & 0o777)
+
+        os.replace(tmp, path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
 
 
 @dataclass
@@ -131,8 +163,7 @@ class AuthConfig:
                 self._KEY_ORG_LEGACY_UUID: self.org_legacy_uuid,
             }
 
-            with open(path, "w") as configfile:
-                config.write(configfile)
+            _write_config_atomically(config, path)
 
     def to_token(self, jwks: Dict[str, Any]) -> OAuth2Token:
         """
@@ -234,8 +265,7 @@ class MachineCredentialConfig:
                 "org_slug": self.org_slug,
             }
 
-            with open(path, "w") as configfile:
-                config.write(configfile)
+            _write_config_atomically(config, path)
 
     @classmethod
     def clear(cls, path: Optional[Path] = None) -> None:
@@ -249,5 +279,4 @@ class MachineCredentialConfig:
             config.read(path)
             if config.has_section(cls._SECTION_MACHINE):
                 config.remove_section(cls._SECTION_MACHINE)
-                with open(path, "w") as configfile:
-                    config.write(configfile)
+                _write_config_atomically(config, path)

--- a/tests/config/test_machine_credential.py
+++ b/tests/config/test_machine_credential.py
@@ -1253,6 +1253,7 @@ class TestSaveIsAtomic:
         assert survivor.machine_token == "tok-original"
 
     @pytest.mark.unit
+    @pytest.mark.unix_only  # Windows chmod only honours the read-only bit
     def test_save_preserves_existing_file_permissions(self, tmp_path: Path) -> None:
         config_path = tmp_path / "auth.ini"
         cred = MachineCredentialConfig(

--- a/tests/config/test_machine_credential.py
+++ b/tests/config/test_machine_credential.py
@@ -1214,3 +1214,53 @@ class TestConcurrentReadAccess:
             success_count += 1
 
         assert success_count == iterations * 2
+
+
+class TestSaveIsAtomic:
+    """
+    save() must never leave the config file empty or partial.
+
+    The file holds the user's credentials. A truncate-then-write loses them
+    outright if the write fails partway, and exposes an empty file to any
+    concurrent reader, since from_storage() takes no lock.
+    """
+
+    @pytest.mark.unit
+    def test_failed_save_leaves_existing_credentials_intact(
+        self, tmp_path: Path
+    ) -> None:
+        config_path = tmp_path / "auth.ini"
+        MachineCredentialConfig(
+            machine_id="m-original",
+            machine_token="tok-original",
+            enrolled_at="2025-01-01T00:00:00Z",
+        ).save(path=config_path)
+
+        replacement = MachineCredentialConfig(
+            machine_id="m-replacement",
+            machine_token="tok-replacement",
+            enrolled_at="2025-02-02T00:00:00Z",
+        )
+
+        # Simulate the process dying midway through writing the new contents.
+        with patch("configparser.ConfigParser.write", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                replacement.save(path=config_path)
+
+        survivor = MachineCredentialConfig.from_storage(path=config_path)
+        assert survivor is not None, "save() destroyed the existing credentials"
+        assert survivor.machine_id == "m-original"
+        assert survivor.machine_token == "tok-original"
+
+    @pytest.mark.unit
+    def test_save_preserves_existing_file_permissions(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "auth.ini"
+        cred = MachineCredentialConfig(
+            machine_id="m-1", machine_token="tok-1", enrolled_at="2025-01-01T00:00:00Z"
+        )
+        cred.save(path=config_path)
+        config_path.chmod(0o600)
+
+        cred.save(path=config_path)
+
+        assert config_path.stat().st_mode & 0o777 == 0o600


### PR DESCRIPTION
## Description

`test_concurrent_read_and_write_dont_corrupt` has been failing intermittently on scheduled runs since 2026-08-27, and now fails on PRs too. It was reporting a real defect, not flaking.

`AuthConfig.save`, `MachineCredentialConfig.save` and `MachineCredentialConfig.clear` all wrote through `open(path, "w")`, which **truncates the file to zero** before the new contents land. `from_storage()` takes no lock at all, so that window hands an empty file to any concurrent reader.

Measured with one writer and two readers, 800 reads:

| | reads returning no data |
| --- | --- |
| before | **91 / 800 (11.4%)**, and 98 / 800 (12.2%) on a second run |
| after | **0 / 800**, across three runs |

On a contended 2-core CI runner that window widens enough to swallow every read in the test's 20-read burst, which produces the observed `assert 0 > 0`.

**The user-facing consequence is worse than the flake.** The file holds credentials. A write that dies partway through — Ctrl-C, OOM, a full disk — leaves `auth.ini` empty, so the user silently loses their login.

## Fix

Write a sibling temp file and rename over the target. `os.replace` is atomic on POSIX and Windows, so a reader sees either the old contents or the new ones, never nothing.

The existing file's permissions are carried over onto the temp file before the rename. Without that, `os.replace` would install the temp file's own default mode and could widen a config a user had tightened.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## Related Issues

Unblocks CI on `main`, and on #915 and #916, which are both currently red from this same test.

## Testing

- [x] Tests added or updated
- [ ] No tests required

- `test_failed_save_leaves_existing_credentials_intact` — patches `ConfigParser.write` to raise midway, then asserts the original credentials are still readable. Deterministic, and it targets the credential-loss consequence rather than the timing window. Watched it fail first with `AssertionError: save() destroyed the existing credentials`.
- `test_save_preserves_existing_file_permissions` — guards the mode carry-over. This one passed before the change, so it exists to stop the fix regressing behaviour rather than to drive it.

Verification:

- [x] Standalone writer/reader harness: 11.4% → 0% empty reads, three consecutive runs at 800 reads each
- [x] The formerly-flaky test run 10 consecutive times, passing every time
- [x] Full suite: 888 passed, 7 skipped, 1 failed
- [x] The one failure is `tests/integration/test_enroll.py::test_enroll_invalid_key_rejected`, which fails identically on pristine `main` (env-dependent, unrelated)
- [x] `ruff check`, `ruff format`, `pyright` clean

## Checklist

- [x] Code is well-documented
- [ ] Changelog is updated (if needed) — auto-generated by commitizen at bump
- [x] No sensitive information (e.g., keys, credentials) is included in the code
- [ ] All PR feedback is addressed

## Additional Notes

Not addressed here, worth a follow-up: `from_storage()` still reads without taking the `FileLock`. Atomic writes make that safe for this failure mode, since there is no longer a torn state to observe, but the asymmetry is worth a deliberate decision rather than being left implicit.
